### PR TITLE
Updated when.map() to process input values in parallel rather than serially.

### DIFF
--- a/when.js
+++ b/when.js
@@ -534,17 +534,13 @@ define([], function() {
      *      the mapped output values.
      */
     function map(promisesOrValues, mapFunc) {
+        var results = [];
 
-        function mapIntoArray(array, value, i) {
-            return when(mapFunc(value), function(resolved) {
-                array[i] = resolved;
-                return array;
-            });
+        for(var i = 0; i < promisesOrValues.length; i++) {
+            results.push(when(promisesOrValues[i]).then(mapFunc));
         }
 
-        var results = allocateArray(promisesOrValues.length);
-
-        return reduce(promisesOrValues, mapIntoArray, results);
+        return when.all(results);
     }
 
     /**


### PR DESCRIPTION
Especially useful for async operations that take a while (e.g. ajax requests).

Performance of the map() operation is also significantly improved with this change (around 4x-5x according to the unit tests).
