### PR TITLE
Cancelable deferreds should resolve normally

### DIFF
--- a/cancelable.js
+++ b/cancelable.js
@@ -41,10 +41,12 @@ define(function() {
 
         // Replace deferred's promise with a promise that will always call canceler() first, *if*
         // deferred is canceled.  Can now safely give out deferred.promise
-        deferred.promise = deferred.then(null,
+        deferred.promise = deferred.then(
+            function(v) { return v; },
             function cancelHandler(e) {
                 throw e === canceled ? canceler(deferred) : e;
-            });
+            }
+        );
 
         // Replace deferred.then to allow it to be called safely and observe the cancellation
         deferred.then = deferred.promise.then;

--- a/test/cancelable.js
+++ b/test/cancelable.js
@@ -39,6 +39,17 @@ buster.testCase('when/cancelable', {
 			}
 		);
 
+	},
+
+	'should invoke the callback with the resolved value': function() {
+		var c = cancelable(when.defer(), function() {});
+		c.then(
+			function(v) {
+				assert.same(1, v);
+				done();
+			}
+		);
+		c.resolve(1);
 	}
 });
 


### PR DESCRIPTION
A resolved cancelable deferred should provide the resolved value to its
callbacks.  It previously always returned null.
