### PR TITLE
when.defer() handler parameter

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -102,15 +102,17 @@ define(['./when'], function(when) {
 	/**
 	 * Replacement for when.defer() that sets up debug logging
 	 * on the created Deferred, its resolver, and its promise.
-	 * @param [id] anything optional identifier for this Deferred that will show
+	 * @param [fn] {Function} Handler function which will be supplied with
+     *  the newly created Deferred instance.
+     * @param [id] anything optional identifier for this Deferred that will show
 	 * up in debug output
 	 * @return {Deferred} a Deferred with debug logging
 	 */
-	function deferDebug() {
+	function deferDebug(fn) {
 		var d, status, value, origResolve, origReject, origThen, id;
 
 		// Delegate to create a Deferred;
-		d = when.defer();
+		d = when.defer(fn);
 
 		status = 'pending';
 		value = pending;

--- a/test/defer.js
+++ b/test/defer.js
@@ -193,7 +193,17 @@ buster.testCase('when.defer', {
 				done();
 			}
 		);
-	}
+	},
+    
+    'supplies deferred instance to handler function': function() {
+        var handlerInvoked = false;
+        when.defer(function(d) { 
+            assert(typeof d.resolve == 'function');
+            handlerInvoked = true;
+        });
+        
+        assert(handlerInvoked);
+    }
 
 });
 

--- a/when.js
+++ b/when.js
@@ -136,9 +136,11 @@ define(function() {
 	 * @memberOf when
 	 * @function
 	 *
+     * @param [fn] {Function} Handler function which will be supplied with
+     *  the newly created Deferred instance.
 	 * @returns {Deferred}
 	 */
-	function defer() {
+	function defer(fn) {
 		var deferred, promise, listeners, progressHandlers, _then, _progress, complete;
 
 		listeners = [];
@@ -302,6 +304,12 @@ define(function() {
 			reject:   (deferred.reject   = reject),
 			progress: (deferred.progress = progress)
 		});
+
+        // If a function was supplied; pass the created deferred instance
+        // through.
+        if (typeof (fn) === 'function') {
+            fn(deferred);
+        }
 
 		return deferred;
 	}


### PR DESCRIPTION
Pull request for Issue #37.

Added optional handler parameter to when.defer() which allows you to resolve / reject a deferred without creating any temporary variables, eg:

```
return when.defer(function (dfd) { 
    dfd.resolve("It's all good!");
});
```
