### PR TITLE
Fix infinite coercion with Q

### DIFF
--- a/when.js
+++ b/when.js
@@ -78,7 +78,18 @@ define(function() { "use strict";
 		} else {
 			// It's not a when.js promise.
 			// Check to see if it's a foreign promise or a value.
-
+			
+			// Some promises, particularly Q promises, provide a valueOf method that
+			// attempts to synchronously return the fulfilled value of the promise, or
+			// returns the unresolved promise itself.  Attempting to break a fulfillment
+			// value out of a promise appears to be necessary to break cycles between
+			// Q and When attempting to coerce each-other's promises in an infinite loop.
+			// For promises that do not implement "valueOf", the Object#valueOf is harmless.
+			// See: https://github.com/kriskowal/q/issues/106
+                        if (promiseOrValue != null && typeof promiseOrValue.valueOf !== "undefined") {
+                        	promiseOrValue = promiseOrValue.valueOf();
+                        }
+                        
 			if(isPromise(promiseOrValue)) {
 				// It looks like a thenable, but we don't know where it came from,
 				// so we don't trust its implementation entirely.  Introduce a trusted


### PR DESCRIPTION
Some promises, particularly Q promises, provide a valueOf method that
attempts to synchronously return the fulfilled value of the promise, or
returns the unresolved promise itself.  Attempting to break a fulfillment
value out of a promise appears to be necessary to break cycles between
Q and When attempting to coerce each-other's promises in an infinite loop.
For promises that do not implement "valueOf", the Object#valueOf is harmless.
See: https://github.com/kriskowal/q/issues/106
