### PR TITLE
Allow when/delay to be externally resolved

### DIFF
--- a/delay.js
+++ b/delay.js
@@ -16,7 +16,7 @@ define(['./when'], function(when) {
     var undef;
 
     /**
-     * Creates a new promise that will resolve after a msec delay.  If promise
+     * Creates a new deferred that will resolve after a msec delay.  If promise
      * is supplied, the delay will start *after* the supplied promise is resolved.
      *
      * Usage:
@@ -39,13 +39,19 @@ define(['./when'], function(when) {
             promise = undef;
         }
 
-        var deferred = when.defer();
+        var deferred, timeout;
 
-        setTimeout(function() {
+        deferred = when.defer();
+        timeout = setTimeout(function() {
             deferred.resolve(promise);
         }, msec);
 
-        return deferred.promise;
+        deferred.promise.always(function () {
+            clearTimeout(timeout);
+            timeout = undef;
+        });
+
+        return deferred;
     };
 
 });

--- a/test/delay.js
+++ b/test/delay.js
@@ -59,6 +59,18 @@ buster.testCase('when/delay', {
 				assert.equals(val, 1);
 			}
 		).always(done);
+	},
+
+	'should clear timeout on reject': function(done) {
+		var d = delay(0);
+		d.reject(1);
+
+		d.then(
+			fail,
+			function(val) {
+				assert.equals(val, 1);
+			}
+		).always(done);
 	}
 });
 })(


### PR DESCRIPTION
- returns a full deferred instead of a promise
- clears the timeout when resolved/rejected
