### PR TITLE
Allow developers to use the tabstop they prefer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,5 +2,4 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 4
 end_of_line = LF


### PR DESCRIPTION
Because `indent_style` is set to `tab`, it doesn't really matter which is the `tabstop` on each editor. The contents of the files will remain the same, regardless of how much horizontal space each developer likes :)

From http://editorconfig.org/#supported-properties

> when indent_style is set to tab it may be desireable to leave indent_size unspecified so readers may view the file using their prefered indentation format.
