### PR TITLE
Update map() to propagate notification/progress events

### DIFF
--- a/when.js
+++ b/when.js
@@ -557,7 +557,7 @@ define(function () {
 						if(!--toResolve) {
 							d.resolve(results);
 						}
-					}, d.reject);
+					}, d.reject, d.notify);
 				};
 
 				// Since mapFunc may be async, get all invocations of it into flight


### PR DESCRIPTION
I noticed that When.all() doesn't propagate notification/progress events and was able to track it down to an omission in When.map().

Thanks for the wonderful library!
