### PR TITLE
Fixed behavior in browser when used with mocha.js version 1.9.0

### DIFF
--- a/when.js
+++ b/when.js
@@ -685,7 +685,7 @@ define(function () {
 		? typeof window === 'undefined'
 			? setImmediate
 			: setImmediate.bind(window)
-		: typeof process === 'object'
+		: typeof process === 'object' && process.nextTick
 			? process.nextTick
 			: function(task) { timeout(task, 0); };
 


### PR DESCRIPTION
There is a problem with defining nextTick function when you use when.js in browser together with Mocha.js 1.9.0

I've just added additional check for existence of method nextTick in process object. 
If doesn't change any logic, but fixes the problem.
