### PR TITLE
Small code path (performance improvement)

### DIFF
--- a/when.js
+++ b/when.js
@@ -305,7 +305,7 @@ define(function () {
 	function coerce(x) {
 		if(x instanceof Promise) {
 			return x;
-		} else if (x !== Object(x)) {
+		} else if (x !== Object(x) || !x.then) {
 			return fulfilled(x);
 		}
 


### PR DESCRIPTION
There's no need to got to the resolve 'untrusted then' code path if non exist (when returning objects that usually don't have 'then' property)
