### PR TITLE
Added a method to attach "Node-style" callbacks as handlers.

### DIFF
--- a/test/promise-test.js
+++ b/test/promise-test.js
@@ -660,6 +660,38 @@ define('when/promise-test', function (require) {
 			}
 		},
 
+		'both': {
+			'should return a promise': function () {
+				assert.isFunction(defer().promise.both().then);
+			},
+
+			'should register callback as callback': function (done) {
+				var d = when.defer();
+
+				d.promise.both(
+					function(err, val) {
+						assert.equals(val, 1);
+						done();
+					}
+				);
+
+				d.resolve(1);
+			},
+
+			'should register callback as errback': function (done) {
+				var d = when.defer();
+
+				d.promise.both(
+					function(err) {
+						assert.equals(err, 1);
+						done();
+					}
+				);
+
+				d.reject(1);
+			}
+		},
+
 		'yield': {
 			'should return a promise': function() {
 				assert.isFunction(defer().promise.yield().then);

--- a/when.js
+++ b/when.js
@@ -96,6 +96,21 @@ define(function () {
 		},
 
 		/**
+		 * Calls combinedCallback with (reason, value) on either fulfillment or
+		 * rejection.
+		 * @param  {function} combinedCallback handler to be called on either
+		 * fulfillment or rejection.
+		 * @return {Promise}
+		 */
+		both: function (combinedCallback) {
+			return this.then(success, combinedCallback);
+
+			function success(value) {
+				return combinedCallback(null, value);
+			}
+		},
+
+		/**
 		 * Shortcut for .then(function() { return value; })
 		 * @param  {*} value
 		 * @return {Promise} a promise that:


### PR DESCRIPTION
**TL;DR:** This makes integrating with callback _users_ easier.

I tried to follow the structure as it was apparent, but please ask for updates if I've missed the mark. This met a need of mine, and I assume others may have similar needs.

**My use case:** I'm building a module for an application that uses promises, but the module is generic enough that I wanted it to accept callbacks, either. Therefore, the API looks thusly:

``` javascript
function clear(callback) {
  var self = this
    , deferred = when.defer()

  self.collection.drop(function (err) {
    if (err) {
      deferred.reject(err)
    } else {
      deferred.resolve(null)
    }
  })

  deferred.promise.both(callback || noop)

  return deferred.promise
}
```

This way, the callback is treated as both a callback and an errback, each a sibling of any downstream `then` handlers.
