### PR TITLE
Only log to window.console if it exists

### DIFF
--- a/monitor/console.js
+++ b/monitor/console.js
@@ -10,10 +10,11 @@
 (function(define) { 'use strict';
 define(function(require) {
 
-	var createAggregator, throttleReporter, simpleReporter, aggregator,
+	var console, createAggregator, throttleReporter, simpleReporter, aggregator,
 		formatter, stackFilter, excludeRx, filter, reporter, logger,
 		rejectionMsg, reasonMsg, filteredFramesMsg;
 
+	console = window.console;
 	createAggregator = require('./aggregator');
 	throttleReporter = require('./throttledReporter');
 	simpleReporter = require('./simpleReporter');
@@ -31,7 +32,9 @@ define(function(require) {
 
 	aggregator = createAggregator(throttleReporter(250, reporter));
 
-	aggregator.publish(console);
+	if(console) {
+		aggregator.publish(console);
+	}
 
 	return aggregator;
 
@@ -40,7 +43,7 @@ define(function(require) {
 	}
 
 	function exclude(line) {
-		var rx = console.promiseStackFilter || excludeRx;
+		var rx = (console && console.promiseStackFilter) || excludeRx;
 		return rx.test(line);
 	}
 

--- a/monitor/logger/consoleGroup.js
+++ b/monitor/logger/consoleGroup.js
@@ -10,13 +10,18 @@
 (function(define) { 'use strict';
 define(function() {
 
+	var console = window.console;
 	var warn, warnAll;
 
-	warn = console.warn ? function(x) { console.warn(x); }
-		: console.log ? function(x) { console.log(x); }
-			: noop;
+	if(console) {
+		warn = console.warn ? function(x) { console.warn(x); }
+			: console.log ? function(x) { console.log(x); }
+				: noop;
+	} else {
+		warn = noop;
+	}
 
-	if(console.groupCollapsed) {
+	if(console && console.groupCollapsed) {
 		warnAll = function(msg, list) {
 			console.groupCollapsed(msg);
 			try {


### PR DESCRIPTION
Some browsers (IE) only have window.console defined if the developer tools window is open. This change removes the assumption that the console object is always defined.
