### PR TITLE
Restore browser based tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	},
 	"scripts": {
 		"test": "jshint . && buster test -e node -r specification && promises-aplus-tests test/promises-aplus-adapter.js",
-		"ci": "npm test",
+		"ci": "npm test && sauceme",
 		"tunnel": "sauceme -m",
 		"start": "buster static -e browser",
 		"benchmark": "node benchmark/promise && node benchmark/map"

--- a/test/buster.js
+++ b/test/buster.js
@@ -17,6 +17,7 @@ config.browser = {
 	resources: [
 		//'**', ** is busted in buster
 		'*.js',
+		'monitor/**/*.js',
 		'node/**/*.js',
 		'unfold/**/*.js',
 		'node_modules/curl/**/*.js'


### PR DESCRIPTION
- allow when/monitor/\* to be served for tests
- add `sauceme` back into the ci script target
