### PR TITLE
Travis env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - 0.8
+  - '0.10'
+  - '0.8'
 script: npm run-script ci
 branches:
   only:


### PR DESCRIPTION
- Update travis environment to not use vars deprecated in test-support@0.3.0.
- Test is Node 0.10 and 0.8
