### PR TITLE
Switch to MutationObserver

### DIFF
--- a/when.js
+++ b/when.js
@@ -838,17 +838,8 @@ define(function (require) {
 		nextTick = process.nextTick;
 	} else if(MutationObserver = global.MutationObserver || global.WebKitMutationObserver) {
 		nextTick = (function(document, MutationObserver, drainQueue) {
-			var mo, el;
-
-			mo = new MutationObserver(drainQueue);
-			el = document.createElement('div');
-			mo.observe(el, { attributes: true });
-
-			// Ensure mo is disconnected to free memory, based on RSVP.js, see:
-			// https://bugs.webkit.org/show_bug.cgi?id=93661
-			global.addEventListener('unload', function() {
-				mo = mo.disconnect(); // set mo to undefined
-			}, false);
+			var el = document.createElement('div');
+			new MutationObserver(drainQueue).observe(el, { attributes: true });
 
 			return function() {
 				el.setAttribute('x', 'x');


### PR DESCRIPTION
This drops `setImmediate` and `MessageChannel` support, relying primarily on `process.nextTick` for all Node versions, and adding `MutationObserver` support as the "fast" browser scheduler.  Vert.x support is unchanged, and everything falls back to `setTimeout` when no fast option is detected.

Definitely looking for feedback.

Fix #197
