### PR TITLE
Re-introduce update to map() to propagate progress/notify events.

### DIFF
--- a/when.js
+++ b/when.js
@@ -701,7 +701,6 @@ define(function (require) {
 				function resolveOne(item, i) {
 					when(item, mapFunc, fallback).then(function(mapped) {
 						results[i] = mapped;
-						notify(mapped);
 
 						if(!--toResolve) {
 							resolve(results);


### PR DESCRIPTION
I submitted a pull request 7 months for this same issue.  The request was accepted and merged but a nearly identical issue has re-emerged sometime since then.

When.all() doesn't propagate notification/progress events and I was able to track it down to an omission in When.map().

There was also an extra call to notify() in the final resolution within map().  If notifications are being properly passed forward during the map call, this final call to notify() becomes extraneous.

Thanks again for the wonderful library!
