### PR TITLE
Add createDeferred method in node/function

### DIFF
--- a/node/function.js
+++ b/node/function.js
@@ -24,6 +24,7 @@ define(function(require) {
 		lift: lift,
 		bind: lift, // DEPRECATED alias for lift
 		createCallback: createCallback,
+		createDeferred: createDeferred,
 		bindCallback: bindCallback,
 		liftCallback: liftCallback
 	};
@@ -178,6 +179,40 @@ define(function(require) {
 				resolver.resolve(value);
 			}
 		};
+	}
+
+	/**
+	 * Creates a deferred that calls the node-style callback when
+	 * the promise resolves or rejects
+	 *
+	 * @example
+	 *	function nodeback(err, value) {
+	 *		// Handle err or use value
+	 *	}
+	 *
+	 *	var nodefn = require('when/node/function');
+	 *
+	 *	var deferred = nodefn.createDeferred(nodeback);
+	 *
+	 *	deferred.resolve('interesting value');
+	 *
+	 * @param  {Function} callback The node-style callback to attach
+	 * @return {Deferred} new Deferred
+	 */
+	function createDeferred(callback) {
+		var d = when.defer();
+		if(callback) {
+			d.promise.then(success, failure);
+		}
+		return d;
+
+		function success(value) {
+			setTimeout(function() { callback(null, value); }, 0);
+		}
+
+		function failure(err) {
+			setTimeout(function() { callback(err, null); }, 0);
+		}
 	}
 
 	/**

--- a/test/node/function-test.js
+++ b/test/node/function-test.js
@@ -292,6 +292,34 @@ define('when/node/function-test', function (require) {
 			}
 		},
 
+		'createDeferred': {
+			'should return a deferred object': function() {
+				assertIsPromise(nodefn.createDeferred().promise);
+			},
+
+			'should register callback as callback': function(done) {
+				function callback(_, val) {
+					assert.same(val, sentinel);
+					done();
+				}
+
+				var d = nodefn.createDeferred(callback);
+
+				d.resolve(sentinel);
+			},
+
+			'should register callback as errback': function(done) {
+				function callback(err) {
+					assert.same(err, sentinel);
+					done();
+				}
+
+				var d = nodefn.createDeferred(callback);
+
+				d.reject(sentinel);
+			}
+		},
+
 		'bindCallback': {
 			'should return a promise': function () {
 				assert.isFunction(nodefn.bindCallback({}, function(){}).then);


### PR DESCRIPTION
This is used for creating a deferred object that call nodeback on resolve or reject.

Q has something like this called nodeify (https://github.com/kriskowal/q/wiki/API-Reference#promisenodeifycallback) and a library called nodeify (https://github.com/then/nodeify).

Stripe API is using When internally, but they had to create this utility themselves (https://github.com/stripe/stripe-node/blob/master/lib/StripeResource.js#L67-L81).

With the prevalence of libraries moving towards the a dual-promise/callback style, I think a method like this would alleviate libraries creating this utility function internally.

Basic tests are included and can probably be expanded on.

In all three libraries mentioned, they are using nextTick or setTimeout to move the callback out of the promise stack.  I think @domenic or @kriskowal would probably be able to explain why this is done.
