### PR TITLE
Clean up the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,10 @@ When.js is cujoJS's lightweight [Promises/A+](http://promises-aplus.github.com/p
 
 It passes the [Promises/A+ Test Suite](https://github.com/promises-aplus/promises-tests), is [very fast](https://github.com/cujojs/promise-perf-tests#test-results) and compact, and has no external dependencies.
 
-What's New?
------------
-
-Check out the [changelog](CHANGES.md) to find out!
-
-Docs & Examples
----------------
-
-[API docs](docs/api.md#api)
-
-[More info on the wiki](https://github.com/cujojs/when/wiki)
-
-[Examples](https://github.com/cujojs/when/wiki/Examples)
+- [What's new](CHANGES.md)
+- [API docs](docs/api.md#api)
+- [Examples](https://github.com/cujojs/when/wiki/Examples)
+- [More info on the wiki](https://github.com/cujojs/when/wiki)
 
 Quick Start
 -----------


### PR DESCRIPTION
I love when.js, but I cringe every time I have to go check out the readme/docs because I know I have to scroll through a boatload of version changelogs before I get there. You guys maintain a changelog file already, there's no reason to duplicate it in the main readme, you can just link to it for those who are interested.

While I was in there working on the readme, I made a few more edits to make the headlines more clear and consistent across the document.

Much :sparkling_heart: for a fantastic library, and hoping you guys are ok with these changes because it would make my (and I think many others') lives much happier every time we go searching for the docs.
