### PR TITLE
add `files[]` for new ender compat to require relative files

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,23 +46,7 @@
 		"microtime": "~0"
 	},
 	"main": "when",
-	"ender": {
-		"files": [
-			"parallel.js",
-			"pipline.js",
-			"poll.js",
-			"sequence.js",
-			"unfold.js",
-			"timeout.js",
-			"timed.js",
-			"delay.js",
-			"keys.js",
-			"guard.js",
-			"function.js",
-			"callbacks.js",
-			"cancelable.js"
-		]
-	},
+	"ender": { "files": ["*.js", "node/*.js", "unfold/*.js", "monitor/*.js"] },
 	"directories": {
 		"test": "test"
 	},


### PR DESCRIPTION
hi there,
in love with your promises implementation and it's heavily in use over here at Change.org. We have a node application which purposes its modules on both server and client. We build our client packages with [Ender](http://enderjs.com) and one of the caveats of using `when` is that we can't require relative modules to the package. Eg: `require('when/parallel')`

We are about to cut a release of Ender@`2.0.0` which [solves](https://github.com/ender-js/Ender/issues/181#issuecomment-22612175) this issue but requires package maintainers to list the files which can be included.

Sorry in advance if this is a PitA.
