### PR TITLE
Allow custom rejection reason for promise.timeout()

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,6 +20,7 @@
 	"noempty": true,
 	"nonew": true,
 	"quotmark": "single",
+	"smarttabs": true,
 	"strict": false,
 	"sub": true,
 	"trailing": true,

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,7 +22,7 @@ API
 	* [promise.else(x)](#promiseelse)
 	* [promise.tap(onFulfilledSideEffect)](#promisetap)
 	* [promise.delay(milliseconds)](#promisedelay)
-	* [promise.timeout(milliseconds)](#promisetimeout)
+	* [promise.timeout(milliseconds, reason)](#promisetimeout)
 	* [promise.inspect()](#promiseinspect)
 	* [promise.with(thisArg)](#promisewith)
 	* [promise.progress(onProgress)](#promiseprogress)
@@ -534,10 +534,12 @@ promise.delay(1000).then(doSomething).catch(handleRejection);
 ## promise.timeout
 
 ```js
-var timedPromise = promise.timeout(milliseconds);
+var timedPromise = promise.timeout(milliseconds, reason);
 ```
 
 Create a new promise that will reject after a timeout if `promise` does not fulfill or reject beforehand.
+
+Optionally specify a custom reason for the timeout rejection; the reason defaults to an `Error`.
 
 ```js
 var node = require('when/node');

--- a/lib/timed.js
+++ b/lib/timed.js
@@ -28,14 +28,17 @@ define(function() {
 		 * this promise fulfills earlier, in which case the returned promise
 		 * fulfills with the same value.
 		 * @param {number} ms milliseconds
+		 * @param {*} [reason=Error] reason the timed out promise is rejected
+		 *   with
 		 * @returns {Promise}
 		 */
-		Promise.prototype.timeout = function(ms) {
-			var self = this;
+		Promise.prototype.timeout = function(ms, reason) {
+			var self = this,
+			    hasReason = arguments.length > 1;
 			return new this.constructor(function(resolve, reject, notify) {
 
 				var timer = setTimer(function onTimeout() {
-					reject(new Error('timed out after ' + ms + 'ms'));
+					reject(hasReason ? reason : new Error('timed out after ' + ms + 'ms'));
 				}, ms);
 
 				self.then(

--- a/test/timeout-test.js
+++ b/test/timeout-test.js
@@ -1,6 +1,6 @@
 (function(buster, define) {
 
-var assert, fail, sentinel;
+var assert, fail, sentinel, undef;
 
 assert = buster.assert;
 fail = buster.assertions.fail;
@@ -59,6 +59,68 @@ define('when/timeout-test', function (require) {
 			).ensure(done);
 
 			d.notify(sentinel);
+		},
+
+		'promise.timeout': {
+
+			'should reject after timeout': function(done) {
+				when.defer().promise.timeout(10).then(
+					fail,
+					function(e) {
+						assert(e instanceof Error);
+					}
+				).ensure(done);
+			},
+
+			'should reject after timeout with the provided reason': function(done) {
+				when.defer().promise.timeout(10, sentinel).then(
+					fail,
+					function(reason) {
+						assert.same(reason, sentinel);
+					}
+				).ensure(done);
+			},
+
+			'should reject after timeout with the provided reason, even if undefined': function(done) {
+				when.defer().promise.timeout(10, undef).then(
+					fail,
+					function(reason) {
+						assert.same(reason, undef);
+					}
+				).ensure(done);
+			},
+
+			'should not timeout when rejected before timeout': function(done) {
+				when.reject(sentinel).timeout(10).then(
+					fail,
+					function(val) {
+						assert.same(val, sentinel);
+					}
+				).ensure(done);
+			},
+
+			'should not timeout when forcibly resolved before timeout': function(done) {
+				when.resolve(sentinel).timeout(10).then(
+					function(val) {
+						assert.same(val, sentinel);
+					},
+					fail
+				).ensure(done);
+			},
+
+			'should propagate progress': function(done) {
+				var d = when.defer();
+
+				d.promise.timeout(10).then(null, null,
+					function(val) {
+						assert.same(val, sentinel);
+						d.resolve();
+					}
+				).ensure(done);
+
+				d.notify(sentinel);
+			}
+
 		}
 
 	});


### PR DESCRIPTION
The signature for promise timeout was:

```
promise.timeout(ms);
```

and is now:

```
promise.timeout(ms[, reason]);
```

If a reason is not specified, a default `Error` is provided with an
appropriate message.

See #279 for discussion.
