### PR TITLE
POC: Always report unhandled rejections, even w/o done()

### DIFF
--- a/lib/decorators/flow.js
+++ b/lib/decorators/flow.js
@@ -34,17 +34,11 @@ define(function() {
 		 */
 		Promise.prototype._maybeFatal = function(x) {
 			if((typeof x === 'object' || typeof x === 'function') && x !== null) {
-				// Delegate to promise._fatal in case it has been overridden
-				resolve(x)._handler.chain(this, void 0, this._fatal);
+				var h = resolve(x)._handler;
+				h.chain(h, void 0, function fatal() {
+					this.join()._fatal();
+				});
 			}
-		};
-
-		/**
-		 * Propagate fatal errors to the host environment.
-		 * @private
-		 */
-		Promise.prototype._fatal = function(e) {
-			this._handler.join()._fatal(e);
 		};
 
 		/**

--- a/lib/decorators/unhandledRejection.js
+++ b/lib/decorators/unhandledRejection.js
@@ -1,0 +1,78 @@
+/** @license MIT License (c) copyright 2010-2014 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+(function(define) { 'use strict';
+define(function(require) {
+
+	var async = require('../async');
+
+	var logError = (function() {
+		if(typeof console !== 'undefined') {
+			if(typeof console.error !== 'undefined') {
+				return function(e) {
+					console.error(e);
+				};
+			}
+
+			if(typeof console.log !== 'undefined') {
+				return function(e) {
+					console.log(e);
+				};
+			}
+		}
+
+		return noop;
+	}());
+
+	return function unhandledRejection(Promise) {
+		var unhandledRejections = [];
+		var queued = false;
+
+		function reportUnhandledRejections() {
+			queued = false;
+			unhandledRejections.forEach(function (r) {
+				if(!r.handled) {
+					logError('Possibly unhandled rejection ' + formatError(r.value));
+				}
+			});
+			unhandledRejections = [];
+		}
+
+		Promise.onUnhandledRejection = function(rejection) {
+			unhandledRejections.push(rejection);
+			if(!queued) {
+				queued = true;
+				async(reportUnhandledRejections);
+			}
+		};
+
+		Promise.onUnhandledRejectionHandled = noop;
+
+		Promise.onFatalRejection = function(rejection) {
+			var e = rejection.value;
+			async(function() {
+				throw e;
+			});
+		};
+
+		return Promise;
+	};
+
+	function formatError(e) {
+		if(typeof e === 'object' && e.stack) {
+			return e.stack;
+		}
+
+		var s = String(e);
+		if(s === '[object Object]' && typeof JSON !== 'undefined') {
+			s = JSON.stringify(e);
+		}
+
+		return s;
+	}
+
+	function noop() {}
+
+});
+}(typeof define === 'function' && define.amd ? define : function(factory) { module.exports = factory(require); }));

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -601,12 +601,12 @@ define(function() {
 		function RejectedHandler(x) {
 			this.value = x;
 			this.state = -1;
+			this.handled = false;
 
 			if(isMonitored()) {
-				this.handled = false;
 				this.context = createContext(this);
-				this._reportTrace();
 			}
+			this._reportTrace();
 		}
 
 		inherit(Handler, RejectedHandler);
@@ -616,11 +616,8 @@ define(function() {
 		};
 
 		RejectedHandler.prototype.when = function(continuation) {
-			if(isMonitored()) {
-				this.handled = true;
-				this._removeTrace();
-				enterContext(this.context);
-			}
+			this._removeTrace();
+			if(isMonitored()) { enterContext(this.context); }
 
 			var x = typeof continuation.rejected === 'function'
 				? tryCatchReject(continuation.rejected, this.value, continuation.receiver)
@@ -632,24 +629,35 @@ define(function() {
 		};
 
 		RejectedHandler.prototype._reportTrace = function(context) {
-			monitor.promiseMonitor.addTrace(this, context);
+			if(isMonitored()) {
+				monitor.promiseMonitor.addTrace(this, context);
+			} else {
+				Promise.onUnhandledRejection(this, context);
+			}
 		};
 
 		RejectedHandler.prototype._removeTrace = function() {
-			monitor.promiseMonitor.removeTrace(this);
+			this.handled = true;
+			if(isMonitored()) {
+				monitor.promiseMonitor.removeTrace(this);
+			} else {
+				Promise.onUnhandledRejectionHandled(this);
+			}
 		};
 
 		RejectedHandler.prototype._fatal = function() {
-			/*global setTimeout*/
 			if(isMonitored()) {
 				monitor.promiseMonitor.fatal(this);
 			} else {
-				var e = this.value;
-				setTimeout(function() {
-					throw e;
-				}, 0);
+				Promise.onFatalRejection(this);
 			}
 		};
+
+		// Unhandled rejection hooks
+
+		Promise.onUnhandledRejection
+			= Promise.onUnhandledRejectionHandled
+			= Promise.onFatalRejection = noop;
 
 		// Execution context tracking for long stack traces
 

--- a/monitor/PromiseMonitor.js
+++ b/monitor/PromiseMonitor.js
@@ -86,8 +86,7 @@ define(function(require) {
 
 	PromiseMonitor.prototype.formatTraces = function(traces) {
 		return traces.map(function(t) {
-			return this._createLongTrace(
-				t.handler.value, t.handler.context, t.extraContext);
+			return this._createLongTrace(t.handler.value, t.handler.context, t.extraContext);
 		}, this);
 	};
 

--- a/test/monitor/deep-chain.js
+++ b/test/monitor/deep-chain.js
@@ -11,7 +11,7 @@
 (function(define) { 'use strict';
 	define(function(require) {
 
-		require('../../monitor/console');
+//		require('../../monitor/console');
 		var Promise = require('../../when').Promise;
 
 		function f1() {

--- a/test/monitor/done.js
+++ b/test/monitor/done.js
@@ -11,14 +11,19 @@
 (function(define) { 'use strict';
 define(function(require) {
 
-	require('../../monitor/console');
+//	require('../../monitor/console');
 	var Promise = require('../../when').Promise;
+//	var Promise = require('bluebird');
 
+//	new Promise(function(r, reject) {
+//		reject(123);
+//	})
 	Promise.resolve(123)
 		.then(function(x) {
-			throw new Error(x);
+			throw new TypeError(x);
 		})
-		.done(console.log);
+//		.then(void 0, function() { console.log(123);})
+//		.done(console.log);
 
 });
 }(typeof define === 'function' && define.amd ? define : function(factory) { module.exports = factory(require); }));

--- a/test/promise-test.js
+++ b/test/promise-test.js
@@ -4,6 +4,7 @@ var refute = buster.refute;
 var fail = buster.referee.fail;
 
 var when = require('../when');
+var Promise = when.Promise;
 
 var sentinel = { value: 'sentinel' };
 var other = { value: 'other' };
@@ -38,6 +39,14 @@ buster.testCase('promise', {
 
 	'done': {
 
+		setUp: function() {
+			this.origOnFatalRejection = Promise.onFatalRejection;
+		},
+
+		tearDown: function() {
+			Promise.onFatalRejection = this.onFatalRejection;
+		},
+
 		'should return undefined': function() {
 			refute.defined(when.resolve().done(f, f));
 			refute.defined(when.reject().done(f, f));
@@ -54,8 +63,8 @@ buster.testCase('promise', {
 			'should be fatal': {
 				'when handleValue throws': function(done) {
 					var p = when.resolve();
-					p._fatal = function testFatal(e) {
-						assert.same(e, sentinel);
+					Promise.onFatalRejection = function testFatal(e) {
+						assert.same(e.value, sentinel);
 						done();
 					};
 
@@ -66,8 +75,8 @@ buster.testCase('promise', {
 
 				'when handleValue rejects': function(done) {
 					var p = when.resolve();
-					p._fatal = function testFatal(e) {
-						assert.same(e, sentinel);
+					Promise.onFatalRejection = function testFatal(e) {
+						assert.same(e.value, sentinel);
 						done();
 					};
 
@@ -89,8 +98,8 @@ buster.testCase('promise', {
 			'should be fatal': {
 				'when no handleFatalError provided': function(done) {
 					var p = when.reject(sentinel);
-					p._fatal = function testFatal(e) {
-						assert.same(e, sentinel);
+					Promise.onFatalRejection = function testFatal(e) {
+						assert.same(e.value, sentinel);
 						done();
 					};
 
@@ -99,8 +108,8 @@ buster.testCase('promise', {
 
 				'when handleFatalError throws': function(done) {
 					var p = when.reject(other);
-					p._fatal = function testFatal(e) {
-						assert.same(e, sentinel);
+					Promise.onFatalRejection = function testFatal(e) {
+						assert.same(e.value, sentinel);
 						done();
 					};
 
@@ -111,8 +120,8 @@ buster.testCase('promise', {
 
 				'when handleFatalError rejects': function(done) {
 					var p = when.reject();
-					p._fatal = function testFatal(e) {
-						assert.same(e, sentinel);
+					Promise.onFatalRejection = function testFatal(e) {
+						assert.same(e.value, sentinel);
 						done();
 					};
 

--- a/test/promises-aplus-adapter.js
+++ b/test/promises-aplus-adapter.js
@@ -5,6 +5,9 @@
 
 		var when = require('../when');
 
+		// Silence potentially unhandled rejections
+		when.Promise.onUnhandledRejection = function() {};
+
 		exports.resolved = when.resolve;
 		exports.rejected = when.reject;
 		exports.deferred = when.defer;

--- a/test/resolve-test.js
+++ b/test/resolve-test.js
@@ -3,8 +3,8 @@ var assert = buster.assert;
 var fail = buster.referee.fail;
 
 var when = require('../when');
-var sentinel = {};
-var other = {};
+var sentinel = { value: 'sentinel' };
+var other = { value: 'other' };
 
 function hasGetters() {
 	try {

--- a/when.js
+++ b/when.js
@@ -17,13 +17,14 @@ define(function (require) {
 	var generate = require('./lib/decorators/iterate');
 	var progress = require('./lib/decorators/progress');
 	var withThis = require('./lib/decorators/with');
+	var unhandledRejection = require('./lib/decorators/unhandledRejection');
 
-	var Promise = [array, flow, generate, progress, inspect, withThis, timed]
-		.reduceRight(function(Promise, feature) {
+	var Promise = [array, flow, generate, progress,
+		inspect, withThis, timed, unhandledRejection]
+		.reduce(function(Promise, feature) {
 			return feature(Promise);
 		}, require('./lib/Promise'));
 
-	var resolve = Promise.resolve;
 	var slice = Array.prototype.slice;
 
 	// Public API
@@ -33,8 +34,8 @@ define(function (require) {
 	when.reject      = Promise.reject;       // Create a rejected promise
 
 	when.lift        = lift;                 // lift a function to return promises
-	when['try']      = tryCall;              // call a function and return a promise
-	when.attempt     = tryCall;              // alias for when.try
+	when['try']      = attempt;              // call a function and return a promise
+	when.attempt     = attempt;              // alias for when.try
 
 	when.iterate     = Promise.iterate;      // Generate a stream of promises
 	when.unfold      = Promise.unfold;       // Generate a stream of promises
@@ -72,7 +73,7 @@ define(function (require) {
 	 *   callback and/or errback is not supplied.
 	 */
 	function when(x, onFulfilled, onRejected, onProgress) {
-		var p = resolve(x);
+		var p = Promise.resolve(x);
 		return arguments.length < 2 ? p : p.then(onFulfilled, onRejected, onProgress);
 	}
 
@@ -103,7 +104,7 @@ define(function (require) {
 	 * @param {function} f
 	 * @returns {Promise}
 	 */
-	function tryCall(f /*, args... */) {
+	function attempt(f /*, args... */) {
 		/*jshint validthis:true */
 		return _apply(f, this, slice.call(arguments, 1));
 	}


### PR DESCRIPTION
### Loud by default

This makes unhandled rejections loud _by default_ (no monitor required, and without using `promise.done`).  The perf impact is nearly zero because it _does not_ track the extra info needed to reconstruct long stack traces.  You get a loud `console.error` message (not a fatal next tick throw) with a "normal" stack trace.
### How it works

When a rejection is created, it immediately puts it into a list.  Then, it sets a timer, if not already set/pending, to run through the rejections list and report all rejections which were not marked as "handled" (literally `rejection.handled == true`) between the time they were created and when the timer fired.

Yes, this relies on timing, but I'm pretty sure there's no better way without garbage collector hooks.  The main worry is, of course, false positives.  There are 2 ways to deal with that:  increase the interval, and allow users to configure/override some parts of the algorithm.  I opted for the latter.
### Configurability

There are 3 public hooks (names subject to tweaking, of course!).  The behavior described above is implemented using these 3 hooks in a new decorator: `lib/decorator/unhandledRejection`.  That means, the es6-shim _does not_ get this new behavior, but also means it doesn't take the added size hit (which is about 200 bytes min+gzip)
1. `Promise.onUnhandledRejection` - called immediately when a rejection is created,
2. `Promise.onUnhandledRejectionHandled` - called immediately when a rejection is "handled" (ie someone calls `then` on it, or "observes" it in any other way), and
3. `Promise.onFatalRejection` - called when an error (rejection or exception) pops out the other side of `promise.done`.
