### PR TITLE
Fixed Typo

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1546,7 +1546,7 @@ A helper function of the `when/node` implementation, which might be useful for c
 
 ```js
 var when   = require('when');
-var nodefn = require('when/node;);
+var nodefn = require('when/node');
 
 function nodeStyleAsyncFunction(callback) {
     if(Math.random() * 2 > 1) {


### PR DESCRIPTION
Added a missing closing single quote so that the code formatting is correct.

Before:

![screen shot 2014-05-29 at 11 15 01 am](https://cloud.githubusercontent.com/assets/480159/3121501/3bfba814-e75d-11e3-9485-e91b128df967.png)

After:

![screen shot 2014-05-29 at 11 18 17 am](https://cloud.githubusercontent.com/assets/480159/3121539/a7b3959e-e75d-11e3-9ba3-e31260bdcef9.png)
