### PR TITLE
Yield to platform before reporting unhandled rejections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ experiments/
 node_modules/
 build/when.js
 test/browser/*.js
+bower_components/

--- a/.jshintignore
+++ b/.jshintignore
@@ -6,3 +6,4 @@ test/monitor/
 test/browser/
 es6-shim/
 build/when.js
+bower_components/

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ build/
 .*
 *~
 bower.json
+bower_components/

--- a/lib/decorators/unhandledRejection.js
+++ b/lib/decorators/unhandledRejection.js
@@ -5,50 +5,82 @@
 (function(define) { 'use strict';
 define(function(require) {
 
-	var async = require('../async');
+	var timer = require('../timer');
 
 	return function unhandledRejection(Promise) {
-		var logError = (function() {
-			if(typeof console !== 'undefined') {
-				if(typeof console.error !== 'undefined') {
-					return function(e) {
-						console.error(e);
-					};
-				}
+		var logError = noop;
+		var logInfo = noop;
 
-				return function(e) {
-					console.log(e);
-				};
-			}
+		if(typeof console !== 'undefined') {
+			logError = typeof console.error !== 'undefined'
+				? function (e) { console.error(e); }
+				: function (e) { console.log(e); };
 
-			return noop;
-		}());
+			logInfo = typeof console.info !== 'undefined'
+				? function (e) { console.info(e); }
+				: function (e) { console.log(e); };
+		}
 
 		Promise.onPotentiallyUnhandledRejection = function(rejection) {
-			logError('Potentially unhandled rejection ' + formatError(rejection.value));
+			enqueue(report, rejection);
+		};
+
+		Promise.onPotentiallyUnhandledRejectionHandled = function(rejection) {
+			enqueue(unreport, rejection);
 		};
 
 		Promise.onFatalRejection = function(rejection) {
-			async(function() {
-				throw rejection.value;
-			});
+			enqueue(throwit, rejection.value);
 		};
+
+		var tasks = [];
+		var reported = [];
+		var running = false;
+
+		function report(r) {
+			if(!r.handled) {
+				reported.push(r);
+				logError('Potentially unhandled rejection [' + r.id + '] ' + formatError(r.value));
+			}
+		}
+
+		function unreport(r) {
+			var i = reported.indexOf(r);
+			if(i >= 0) {
+				reported.splice(i, 1);
+				logInfo('Handled previous rejection [' + r.id + '] ' + formatObject(r.value));
+			}
+		}
+
+		function enqueue(f, x) {
+			tasks.push(f, x);
+			if(!running) {
+				running = true;
+				running = timer.set(flush, 0);
+			}
+		}
+
+		function flush() {
+			running = false;
+			while(tasks.length > 0) {
+				tasks.shift()(tasks.shift());
+			}
+		}
 
 		return Promise;
 	};
 
 	function formatError(e) {
-		var s;
-		if(typeof e === 'object' && e.stack) {
-			s = e.stack;
-		} else {
-			s = String(e);
-			if(s === '[object Object]' && typeof JSON !== 'undefined') {
-				s = tryStringify(e, s);
-			}
-		}
-
+		var s = typeof e === 'object' && e.stack ? e.stack : formatObject(e);
 		return e instanceof Error ? s : s + ' (WARNING: non-Error used)';
+	}
+
+	function formatObject(o) {
+		var s = String(o);
+		if(s === '[object Object]' && typeof JSON !== 'undefined') {
+			s = tryStringify(o, s);
+		}
+		return s;
 	}
 
 	function tryStringify(e, defaultValue) {
@@ -58,6 +90,10 @@ define(function(require) {
 			// Ignore. Cannot JSON.stringify e, stick with String(e)
 			return defaultValue;
 		}
+	}
+
+	function throwit(e) {
+		throw e;
 	}
 
 	function noop() {}

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -24,8 +24,6 @@ define(function() {
 		 */
 		function Promise(resolver, handler) {
 			this._handler = resolver === Handler ? handler : init(resolver);
-//			this._handler = arguments.length === 0
-//				? foreverPendingHandler : init(resolver);
 		}
 
 		/**
@@ -85,7 +83,7 @@ define(function() {
 		 * @return {Promise} promise
 		 */
 		function resolve(x) {
-			return x instanceof Promise ? x
+			return isPromise(x) ? x
 				: new Promise(Handler, new AsyncHandler(getHandler(x)));
 		}
 
@@ -130,7 +128,7 @@ define(function() {
 		Promise.prototype.then = function(onFulfilled, onRejected) {
 			var parent = this._handler;
 
-			if (typeof onFulfilled !== 'function' && parent.join().state > 0) {
+			if (typeof onFulfilled !== 'function' && parent.join().state() > 0) {
 				// Short circuit: value will not change, simply share handler
 				return new Promise(Handler, parent);
 			}
@@ -218,7 +216,7 @@ define(function() {
 			var pending = promises.length >>> 0;
 			var results = new Array(pending);
 
-			var i, h, x;
+			var i, h, x, s;
 			for (i = 0; i < promises.length; ++i) {
 				x = promises[i];
 
@@ -228,13 +226,14 @@ define(function() {
 				}
 
 				if (maybeThenable(x)) {
-					h = x instanceof Promise
+					h = isPromise(x)
 						? x._handler.join()
 						: getHandlerUntrusted(x);
 
-					if (h.state === 0) {
+					s = h.state();
+					if (s === 0) {
 						resolveOne(resolver, results, h, i);
-					} else if (h.state > 0) {
+					} else if (s > 0) {
 						results[i] = h.value;
 						--pending;
 					} else {
@@ -304,10 +303,14 @@ define(function() {
 		 * @returns {object} handler
 		 */
 		function getHandler(x) {
-			if(x instanceof Promise) {
+			if(isPromise(x)) {
 				return x._handler.join();
 			}
 			return maybeThenable(x) ? getHandlerUntrusted(x) : new FulfilledHandler(x);
+		}
+
+		function isPromise(x) {
+			return x instanceof Promise;
 		}
 
 		/**
@@ -331,9 +334,7 @@ define(function() {
 		 * @private
 		 * @constructor
 		 */
-		function Handler() {
-			this.state = 0;
-		}
+		function Handler() {}
 
 		Handler.prototype.when
 			= Handler.prototype.resolve
@@ -345,6 +346,12 @@ define(function() {
 			= noop;
 
 		Handler.prototype.inspect = toPendingState;
+
+		Handler.prototype._state = 0;
+
+		Handler.prototype.state = function() {
+			return this._state;
+		};
 
 		/**
 		 * Recursively collapse handler chain to find the handler
@@ -399,10 +406,11 @@ define(function() {
 			this.receiver = receiver;
 			this.handler = void 0;
 			this.resolved = false;
-			this.state = 0;
 		}
 
 		inherit(Handler, DeferredHandler);
+
+		DeferredHandler.prototype._state = 0;
 
 		DeferredHandler.prototype.inspect = function() {
 			return this.resolved ? this.join().inspect() : toPendingState();
@@ -496,7 +504,6 @@ define(function() {
 		 */
 		function DelegateHandler(handler) {
 			this.handler = handler;
-			this.state = 0;
 		}
 
 		inherit(Handler, DelegateHandler);
@@ -576,12 +583,12 @@ define(function() {
 		 */
 		function FulfilledHandler(x) {
 			Promise.createContext(this);
-
 			this.value = x;
-			this.state = 1;
 		}
 
 		inherit(Handler, FulfilledHandler);
+
+		FulfilledHandler.prototype._state = 1;
 
 		FulfilledHandler.prototype.inspect = function() {
 			return { state: 'fulfilled', value: this.value };
@@ -601,6 +608,7 @@ define(function() {
 			cont.resolve.call(cont.context, x);
 		};
 
+		var id = 0;
 		/**
 		 * Handler for a rejected promise
 		 * @private
@@ -610,14 +618,17 @@ define(function() {
 		function RejectedHandler(x) {
 			Promise.createContext(this);
 
+			this.id = ++id;
 			this.value = x;
-			this.state = -1; // -1: rejected, -2: rejected and reported
 			this.handled = false;
+			this.reported = false;
 
 			this._report();
 		}
 
 		inherit(Handler, RejectedHandler);
+
+		RejectedHandler.prototype._state = -1;
 
 		RejectedHandler.prototype.inspect = function() {
 			return { state: 'rejected', reason: this.value };
@@ -654,13 +665,13 @@ define(function() {
 
 		function reportUnhandled(rejection, context) {
 			if(!rejection.handled) {
-				rejection.state = -2;
+				rejection.reported = true;
 				Promise.onPotentiallyUnhandledRejection(rejection, context);
 			}
 		}
 
 		function reportHandled(rejection) {
-			if(rejection.state === -2) {
+			if(rejection.reported) {
 				Promise.onPotentiallyUnhandledRejectionHandled(rejection);
 			}
 		}

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -56,12 +56,12 @@ define(function(require) {
 			q.shift().run();
 		}
 
+		this._running = false;
+
 		q = this._afterQueue;
 		while(q.length > 0) {
 			q.shift()(q.shift(), q.shift());
 		}
-
-		this._running = false;
 	};
 
 	return Scheduler;

--- a/test/monitor/all.js
+++ b/test/monitor/all.js
@@ -11,7 +11,7 @@
 (function(define) { 'use strict';
 	define(function(require) {
 
-		require('../../monitor/console');
+//		require('../../monitor/console');
 
 		var when = require('../../when');
 

--- a/test/monitor/deep-chain.js
+++ b/test/monitor/deep-chain.js
@@ -11,7 +11,7 @@
 (function(define) { 'use strict';
 	define(function(require) {
 
-		require('../../monitor/console');
+//		require('../../monitor/console');
 		var Promise = require('../../when').Promise;
 
 		function f1() {
@@ -36,8 +36,8 @@
 		// and this will be logged as well.
 		setTimeout(function() {
 			console.log('*** handling rejection ***');
-			p.done();
-//			p.catch(ok);
+//			p.done();
+			p.catch(ok);
 		}, 1337);
 
 		function ok(x) {

--- a/test/monitor/developer-error.js
+++ b/test/monitor/developer-error.js
@@ -11,7 +11,7 @@
 (function(define) { 'use strict';
 define(function(require) {
 
-	require('../../monitor/console');
+//	require('../../monitor/console');
 
 	var Promise = require('../../when').Promise;
 

--- a/test/monitor/done.js
+++ b/test/monitor/done.js
@@ -16,13 +16,14 @@ define(function(require) {
 
 	Promise.resolve(123)
 		.then(function(x) {
-			throw x;
+//			throw x;
+			throw new Error(x);
 //			return Promise.reject(x);
 //			foo();
 //			throw new TypeError(x);
-		});
+		})
 //		.then(void 0, function() { console.log(123);})
-//		.done(console.log);
+		.done(console.log);
 
 });
 }(typeof define === 'function' && define.amd ? define : function(factory) { module.exports = factory(require); }));

--- a/test/monitor/index.html
+++ b/test/monitor/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title></title>
-    <script type="text/javascript" src="../../node_modules/curl/src/curl.js"></script>
+    <script type="text/javascript" src="../../bower_components/curl/src/curl.js"></script>
     <script type="text/javascript">
         curl.config({
             packages: {
@@ -11,7 +11,7 @@
             }
         });
 
-        curl(['./deep-chain']);
+        curl(['./done']);
     </script>
 </head>
 <body>

--- a/test/monitor/lift-node.js
+++ b/test/monitor/lift-node.js
@@ -1,8 +1,9 @@
-require('../../monitor/console');
+//require('../../monitor/console');
 var node = require('../../node');
 
-function test() {
+function test(cb) {
 	throw new Error('fail');
+//	cb(new Error('fail'));
 }
 
 var f = node.lift(test);

--- a/test/monitor/map.js
+++ b/test/monitor/map.js
@@ -11,7 +11,7 @@
 (function(define) { 'use strict';
 	define(function(require) {
 
-		require('../../monitor/console');
+//		require('../../monitor/console');
 
 		var when = require('../../when');
 

--- a/test/monitor/unhandled-begets-unhandled.js
+++ b/test/monitor/unhandled-begets-unhandled.js
@@ -19,7 +19,7 @@ define(function(require) {
 	var p = new Promise.reject(new Error('first error'));
 
 	setTimeout(function() {
-		console.log('***Begetting new unhandled error now***');
+//		console.log('***Begetting new unhandled error now***');
 		p['catch'](function() {
 			throw new Error('unhandled-begets-unhandled');
 		});

--- a/test/monitor/unhandled-forever.js
+++ b/test/monitor/unhandled-forever.js
@@ -11,7 +11,7 @@
 (function(define) { 'use strict';
 	define(function(require) {
 
-		require('../../monitor/console');
+//		require('../../monitor/console');
 
 		var Promise = require('../../when').Promise;
 

--- a/test/monitor/unhandled-handled-later.js
+++ b/test/monitor/unhandled-handled-later.js
@@ -11,18 +11,29 @@
 (function(define) { 'use strict';
 define(function(require) {
 
-	require('../../monitor/console');
+//	require('../../monitor/console');
 
 	var Promise = require('../../when').Promise;
+//	var Promise = require('bluebird');
 
-	var p = new Promise(function(_, reject) {
-		reject(new Error('unhandled-handled-later'));
-	});
+	function run() {
+		var p = new Promise(function(_, reject) {
+			reject(new Error('unhandled-handled-later'));
+		});
 
-	setTimeout(function() {
-		console.log('***Handling error now***');
-		p['catch'](function() { /* handled by squelching */ });
-	}, 1000);
+		setTimeout(function() {
+//			console.log('***Handling error now***');
+			p['catch'](function() { /* handled by squelching */ });
+		}, 1000);
+	}
+
+	run();
+//	run();
+//	run();
+//	run();
+//	run();
+//	run();
+//	run();
 
 });
 }(typeof define === 'function' && define.amd ? define : function(factory) { module.exports = factory(require); }));


### PR DESCRIPTION
to allow time for other promise implementations (including other copies of when in
the same VM, a la node/npm) to handle rejections in their scheduler
queue.  Reduces false positives when mixing promise implementations.

Report when previously unhandled rejections become handled,
correlating the two messages with an id.

Fix #325
