### PR TITLE
Add when.filter.  Pass array indices and object keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### 3.4.0
+
+* New [`when.filter`](docs/api.md#whenfilter) for filtering array of promises
+* [`when.map`](docs/api.md#whenmap) and [`when.filter`](docs/api.md#whenfilter) now provide the array index as the second param to their mapping and filtering functions.
+* [`when/keys.map`](docs/api.md#whenkeys-map) now provides the associated key to its mapping function.
+* Smaller ES6 shim.
+
 ### 3.3.1
 
 * Fix argument ordering bug in `when/node` introduced in 3.3.0.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "when",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "main": "when.js",
   "moduleType": ["amd", "node"],
   "description": "A lightweight Promises/A+ and when() implementation, plus other async goodies.",

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,7 @@ API
 	* [when.all(array)](#whenall)
 	* [when.settle(array)](#whensettle)
 	* [when.map(array, mapper)](#whenmap)
+	* [when.filter(array, predicate)](#whenfilter)
 	* [when.reduce(array, reducer)](#whenreduce)
 	* [when.reduceRight(array, reducer)](#whenreduceright)
 1. Array Races
@@ -794,7 +795,7 @@ var promise = when.map(array, mapper)
 
 Where:
 
-* array is an Array *or a promise for an array*, which may contain promises and/or values.
+* array is an Array or promise for an Array, which may contain promises and/or values
 
 Traditional array map function, similar to `Array.prototype.map()`, but allows input to contain promises and/or values, and mapFunc may return either a value or a promise.
 
@@ -803,12 +804,38 @@ If any of the promises is rejected, the returned promise will be rejected with t
 The map function should have the signature:
 
 ```js
-mapFunc(item)
+mapFunc(value:*, index:Number):*
 ```
 
 Where:
 
-* `item` is a fully resolved value
+* `value` fulfilled value
+* `index` array index of `value`
+
+## when.filter
+
+```js
+var promise = when.filter(array, predicate);
+```
+
+Where:
+
+* array is an Array or promise for an Array, which may contain promises and/or values
+
+Filters the input array, returning a promise for the filtered array.  The filtering `predicate` may return a boolean or promise for boolean.
+
+If any of the promises is rejected, the returned promise will be rejected with the rejection reason of the first promise that was rejected.
+
+The predicate should have the signature:
+
+```js
+predicate(value:*, index:Number):boolean
+```
+
+Where:
+
+* `value` fulfilled value
+* `index` array index of `value`
 
 ## when.reduce
 ## when.reduceRight
@@ -827,7 +854,7 @@ Traditional array reduce function, similar to `Array.prototype.reduce()` and `Ar
 The reduce function should have the signature:
 
 ```js
-reducer(currentResult, value, index, total)
+reducer(currentResult, value, index)
 ```
 
 Where:
@@ -835,7 +862,6 @@ Where:
 * `currentResult` is the current accumulated reduce value
 * `value` is the fully resolved value at `index` in `array`
 * `index` is the *basis* of `value` ... practically speaking, this is the array index of the array corresponding to `value`
-* `total` is the total number of items in `array`
 
 ```js
 // sum the eventual values of several promises
@@ -922,12 +948,13 @@ If any of the promises is rejected, the returned promise will be rejected with t
 The map function should have the signature:
 
 ```js
-mapFunc(value)
+mapFunc(value:*, key:String):*
 ```
 
 Where:
 
-* `value` is a fully resolved value
+* `value` fulfilled value
+* `key` key corresponding to `value`
 
 ### See also:
 * [when.map](#whenmap)

--- a/es6-shim/Promise.js
+++ b/es6-shim/Promise.js
@@ -512,17 +512,6 @@ define(function() {
 		};
 
 		/**
-		 * Private function to bind a thisArg for this promise's handlers
-		 * @private
-		 * @param {object} thisArg `this` value for all handlers attached to
-		 *  the returned promise.
-		 * @returns {Promise}
-		 */
-//		Promise.prototype._bindContext = function(thisArg) {
-//			return new Promise(Handler, new Bound(this._handler, thisArg));
-//		};
-
-		/**
 		 * Creates a new, pending promise of the same type as this promise
 		 * @private
 		 * @returns {Promise}

--- a/lib/decorators/array.js
+++ b/lib/decorators/array.js
@@ -7,10 +7,8 @@ define(function() {
 
 	return function array(Promise) {
 
-		var arrayMap = Array.prototype.map;
 		var arrayReduce = Array.prototype.reduce;
 		var arrayReduceRight = Array.prototype.reduceRight;
-		var arrayForEach = Array.prototype.forEach;
 
 		var toPromise = Promise.resolve;
 		var all = Promise.all;
@@ -22,6 +20,7 @@ define(function() {
 		Promise.settle = settle;
 
 		Promise.map = map;
+		Promise.filter = filter;
 		Promise.reduce = reduce;
 		Promise.reduceRight = reduceRight;
 
@@ -119,29 +118,69 @@ define(function() {
 			});
 		}
 
+		/**
+		 * Initialize a race observing each promise in the input promises
+		 * @param {Array} promises
+		 * @param {function} resolve
+		 * @param {function} reject
+		 * @param {?function=} notify
+		 * @returns {Number} actual count of items being raced
+		 */
 		function initRace(promises, resolve, reject, notify) {
-			var pending = 0;
-
-			arrayForEach.call(promises, function(p) {
-				++pending;
+			return arrayReduce.call(promises, function(pending, p) {
 				toPromise(p).then(resolve, reject, notify);
-			});
-
-			return pending;
+				return pending + 1;
+			}, 0);
 		}
 
 		/**
 		 * Apply f to the value of each promise in a list of promises
 		 * and return a new list containing the results.
 		 * @param {array} promises
-		 * @param {function} f
-		 * @param {function} fallback
+		 * @param {function(x:*, index:Number):*} f mapping function
 		 * @returns {Promise}
 		 */
-		function map(promises, f, fallback) {
-			return all(arrayMap.call(promises, function(x) {
-				return toPromise(x).then(f, fallback);
-			}));
+		function map(promises, f) {
+			if(typeof promises !== 'object') {
+				return toPromise([]);
+			}
+
+			return all(mapArray(function(x, i) {
+				return toPromise(x).fold(mapWithIndex, i);
+			}, promises));
+
+			function mapWithIndex(k, x) {
+				return f(x, k);
+			}
+		}
+
+		/**
+		 * Filter the provided array of promises using the provided predicate.  Input may
+		 * contain promises and values
+		 * @param {Array} promises array of promises and values
+		 * @param {function(x:*, index:Number):boolean} predicate filtering predicate.
+		 *  Must return truthy (or promise for truthy) for items to retain.
+		 * @returns {Promise} promise that will fulfill with an array containing all items
+		 *  for which predicate returned truthy.
+		 */
+		function filter(promises, predicate) {
+			return all(promises).then(function(values) {
+				return all(mapArray(predicate, values)).then(function(results) {
+					var len = results.length;
+					var filtered = new Array(len);
+					for(var i=0, j= 0, x; i<len; ++i) {
+						x = results[i];
+						if(x === void 0 && !(i in results)) {
+							continue;
+						}
+						if(results[i]) {
+							filtered[j++] = values[i];
+						}
+					}
+					filtered.length = j;
+					return filtered;
+				});
+			});
 		}
 
 		/**
@@ -149,19 +188,25 @@ define(function() {
 		 * the outcome states of all input promises.  The returned promise
 		 * will never reject.
 		 * @param {array} promises
-		 * @returns {Promise}
+		 * @returns {Promise} promise for array of settled state descriptors
 		 */
 		function settle(promises) {
-			return all(arrayMap.call(promises, function(p) {
+			return all(mapArray(function(p) {
 				p = toPromise(p);
 				return p.then(inspect, inspect);
 
 				function inspect() {
 					return p.inspect();
 				}
-			}));
+			}, promises));
 		}
 
+		/**
+		 * Reduce an array of promises and values
+		 * @param {Array} promises
+		 * @param {function(accumulated:*, x:*, index:Number):*} f reduce function
+		 * @returns {Promise} promise for reduced value
+		 */
 		function reduce(promises, f) {
 			var reducer = makeReducer(f);
 			return arguments.length > 2
@@ -169,6 +214,12 @@ define(function() {
 				: arrayReduce.call(promises, reducer);
 		}
 
+		/**
+		 * Reduce an array of promises and values from the right
+		 * @param {Array} promises
+		 * @param {function(accumulated:*, x:*, index:Number):*} f reduce function
+		 * @returns {Promise} promise for reduced value
+		 */
 		function reduceRight(promises, f) {
 			var reducer = makeReducer(f);
 			return arguments.length > 2
@@ -184,6 +235,19 @@ define(function() {
 					});
 				});
 			};
+		}
+
+		function mapArray(f, a) {
+			var l = a.length;
+			var b = new Array(l);
+			for(var i=0, x; i<l; ++i) {
+				x = a[i];
+				if(x === void 0 && !(i in a)) {
+					continue;
+				}
+				b[i] = f(a[i], i);
+			}
+			return b;
 		}
 	};
 

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -154,17 +154,6 @@ define(function() {
 		};
 
 		/**
-		 * Private function to bind a thisArg for this promise's handlers
-		 * @private
-		 * @param {object} thisArg `this` value for all handlers attached to
-		 *  the returned promise.
-		 * @returns {Promise}
-		 */
-//		Promise.prototype._bindContext = function(thisArg) {
-//			return new Promise(Handler, new Bound(this._handler, thisArg));
-//		};
-
-		/**
 		 * Creates a new, pending promise of the same type as this promise
 		 * @private
 		 * @returns {Promise}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "when",
-	"version": "3.3.1",
+	"version": "3.4.0",
 	"description": "A lightweight Promises/A+ and when() implementation, plus other async goodies.",
 	"keywords": [
 		"cujo",

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -1,0 +1,78 @@
+var buster = typeof window !== 'undefined' ? window.buster : require('buster');
+var assert = buster.assert;
+
+var when = require('../when');
+var sentinel = { value: 'sentinel' };
+
+function even(x) {
+	return x % 2 === 0;
+}
+
+function evenPromise(x) {
+	return when(even(x));
+}
+
+buster.testCase('when.filter', {
+
+	'should pass index to predicate as second param': function() {
+		return when.filter(['a','b','c'], function(x, i) {
+			assert(typeof i === 'number');
+			return true;
+		});
+	},
+
+	'should filter input values array': function() {
+		var input = [1, 2, 3];
+		return when.filter(input, even).then(
+			function(results) {
+				assert.equals(input.filter(even), results);
+			});
+	},
+
+	'should filter input promises array': function() {
+		var input = [1, 2, 3];
+		return when.filter(input.map(when), even).then(
+			function(results) {
+				assert.equals(input.filter(even), results);
+			});
+	},
+
+	'should filter input when predicate returns a promise': function() {
+		var input = [1,2,3];
+		return when.filter(input, evenPromise).then(
+			function(results) {
+				assert.equals(input.filter(even), results);
+			});
+	},
+
+	'should accept a promise for an array': function() {
+		var input = [1,2,3];
+		return when.filter(when(input), even).then(
+			function(results) {
+				assert.equals(input.filter(even), results);
+			});
+	},
+
+	'should fulfill with empty array when input promise fulfills with non-array': function() {
+		return when.filter(when(123), even).then(
+			function(result) {
+				assert.equals(result, []);
+			});
+	},
+
+	'should reject when input contains rejection': function() {
+		var input = [when(1), when.reject(sentinel), 3];
+		return when.filter(input, even)['catch'](
+			function(e) {
+				assert.same(e, sentinel);
+			});
+	},
+
+	'should reject when input is a rejected promise': function() {
+		return when.filter(when.reject(sentinel), even)['catch'](
+			function(e) {
+				assert.same(e, sentinel);
+			});
+	}
+
+});

--- a/test/keys-test.js
+++ b/test/keys-test.js
@@ -79,6 +79,15 @@ buster.testCase('when/keys', {
 	},
 
 	'map': {
+		'should pass key as second param': function() {
+			var input = { a:1, b:2, c:3 };
+			return keys.map(input, function(x, k) {
+				assert(typeof k === 'string' && input.hasOwnProperty(k));
+				return x;
+			});
+
+		},
+
 		'should resolve empty input': function() {
 			return keys.map({}).then(assertNoKeys);
 		},

--- a/test/map-test.js
+++ b/test/map-test.js
@@ -22,6 +22,13 @@ function identity(x) {
 
 buster.testCase('when.map', {
 
+	'should pass index to predicate as second param': function() {
+		return when.map(['a','b','c'], function(x, i) {
+			assert(typeof i === 'number');
+			return x;
+		});
+	},
+
 	'should map input values array': function(done) {
 		var input = [1, 2, 3];
 		when.map(input, mapper).then(

--- a/test/reduce-test.js
+++ b/test/reduce-test.js
@@ -119,7 +119,7 @@ buster.testCase('when.reduce', {
 				return arr;
 			}
 
-			return when.reduceRight([later(1), later(2), later(3)], insert, []).then(
+			return when.reduceRight([when(1), when(2), when(3)], insert, []).then(
 				function(result) {
 					assert.equals(result, [1,2,3]);
 				});
@@ -220,7 +220,7 @@ buster.testCase('when.reduce', {
 		},
 
 		'should reduce in input order': function() {
-			return when.reduce([later(1), later(2), later(3)], plus, '').then(
+			return when.reduce([later(1), when(2), when(3)], plus, '').then(
 				function(result) {
 					assert.equals(result, '123');
 				});
@@ -246,7 +246,7 @@ buster.testCase('when.reduce', {
 				return arr;
 			}
 
-			return when.reduce([later(1), later(2), later(3)], insert, []).then(
+			return when.reduce([when(1), when(2), when(3)], insert, []).then(
 				function(result) {
 					assert.equals(result, [1,2,3]);
 				});

--- a/when.js
+++ b/when.js
@@ -5,7 +5,7 @@
  * when is part of the cujoJS family of libraries (http://cujojs.com/)
  * @author Brian Cavalier
  * @author John Hann
- * @version 3.3.1
+ * @version 3.4.0
  */
 (function(define) { 'use strict';
 define(function (require) {
@@ -52,6 +52,7 @@ define(function (require) {
 	when.race        = lift(Promise.race);   // First-to-settle race
 
 	when.map         = map;                  // Array.map() for promises
+	when.filter      = filter;               // Array.filter() for promises
 	when.reduce      = reduce;               // Array.reduce() for promises
 	when.reduceRight = reduceRight;          // Array.reduceRight() for promises
 
@@ -193,7 +194,7 @@ define(function (require) {
 	 * the outcome states of all input promises.  The returned promise
 	 * will only reject if `promises` itself is a rejected promise.
 	 * @param {array|Promise} promises array (or promise for an array) of promises
-	 * @returns {Promise}
+	 * @returns {Promise} promise for array of settled state descriptors
 	 */
 	function settle(promises) {
 		return when(promises, Promise.settle);
@@ -203,7 +204,8 @@ define(function (require) {
 	 * Promise-aware array map function, similar to `Array.prototype.map()`,
 	 * but input array may contain promises or values.
 	 * @param {Array|Promise} promises array of anything, may contain promises and values
-	 * @param {function} mapFunc map function which may return a promise or value
+	 * @param {function(x:*, index:Number):*} mapFunc map function which may
+	 *  return a promise or value
 	 * @returns {Promise} promise that will fulfill with an array of mapped values
 	 *  or reject if any input promise rejects.
 	 */
@@ -214,14 +216,28 @@ define(function (require) {
 	}
 
 	/**
+	 * Filter the provided array of promises using the provided predicate.  Input may
+	 * contain promises and values
+	 * @param {Array|Promise} promises array of promises and values
+	 * @param {function(x:*, index:Number):boolean} predicate filtering predicate.
+	 *  Must return truthy (or promise for truthy) for items to retain.
+	 * @returns {Promise} promise that will fulfill with an array containing all items
+	 *  for which predicate returned truthy.
+	 */
+	function filter(promises, predicate) {
+		return when(promises, function(promises) {
+			return Promise.filter(promises, predicate);
+		});
+	}
+
+	/**
 	 * Traditional reduce function, similar to `Array.prototype.reduce()`, but
 	 * input may contain promises and/or values, and reduceFunc
 	 * may return either a value or a promise, *and* initialValue may
 	 * be a promise for the starting value.
-	 *
 	 * @param {Array|Promise} promises array or promise for an array of anything,
 	 *      may contain a mix of promises and values.
-	 * @param {function} f reduce function reduce(currentValue, nextValue, index)
+	 * @param {function(accumulated:*, x:*, index:Number):*} f reduce function
 	 * @returns {Promise} that will resolve to the final reduced value
 	 */
 	function reduce(promises, f /*, initialValue */) {
@@ -238,10 +254,9 @@ define(function (require) {
 	 * input may contain promises and/or values, and reduceFunc
 	 * may return either a value or a promise, *and* initialValue may
 	 * be a promise for the starting value.
-	 *
 	 * @param {Array|Promise} promises array or promise for an array of anything,
 	 *      may contain a mix of promises and values.
-	 * @param {function} f reduce function reduce(currentValue, nextValue, index)
+	 * @param {function(accumulated:*, x:*, index:Number):*} f reduce function
 	 * @returns {Promise} that will resolve to the final reduced value
 	 */
 	function reduceRight(promises, f /*, initialValue */) {


### PR DESCRIPTION
Add when.filter(promises, predicate).  Predicate can return a boolean or promise for boolean.  Close #337.

Make when.filter, when.map pass index as second param, when/keys.map pass key as second param.  Close #134.
