### PR TITLE
Workaround bug in node 0.10.30 timers that causes an infinite loop

### DIFF
--- a/lib/timer.js
+++ b/lib/timer.js
@@ -14,7 +14,9 @@ define(function(require) {
 		setTimer = function (f, ms) { return vertx.setTimer(ms, f); };
 		clearTimer = vertx.cancelTimer;
 	} catch (e) {
-		setTimer = function(f, ms) { return setTimeout(f, ms); };
+		// NOTE: Truncate decimals to workaround node 0.10.30 bug:
+		// https://github.com/joyent/node/issues/8167
+		setTimer = function(f, ms) { return setTimeout(f, ms|0); };
 		clearTimer = function(t) { return clearTimeout(t); };
 	}
 


### PR DESCRIPTION
when passing decimals.  See joyent/node#8167

Current this manifests in unit tests by locking up map-test
