### PR TITLE
Exclude vertx module from browser bundles

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -42,20 +42,20 @@ define(function(require) {
 
 	} else {
 		nextTick = (function(cjsRequire) {
-            var vertx;
+			var vertx;
 			try {
 				// vert.x 1.x || 2.x
-                vertx = cjsRequire('vertx');
+				vertx = cjsRequire('vertx');
 			} catch (ignore) {}
 
-            if (vertx) {
-                if (typeof vertx.runOnLoop === 'function') {
-                    return vertx.runOnLoop;
-                }
-                if (typeof vertx.runOnContext === 'function') {
-                    return vertx.runOnContext;
-                }
-            }
+			if (vertx) {
+				if (typeof vertx.runOnLoop === 'function') {
+					return vertx.runOnLoop;
+				}
+				if (typeof vertx.runOnContext === 'function') {
+					return vertx.runOnContext;
+				}
+			}
 
 			// capture setTimeout to avoid being caught by fake timers
 			// used in time based tests

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -11,9 +11,9 @@ define(function(require) {
 
 	try {
 		vertx = cjsRequire('vertx');
-    } catch (e) { }
+	} catch (e) { }
 
-    if (vertx && typeof vertx.setTimer === 'function') {
+	if (vertx && typeof vertx.setTimer === 'function') {
 		setTimer = function (f, ms) { return vertx.setTimer(ms, f); };
 		clearTimer = vertx.cancelTimer;
 	} else {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"browserify": "browserify -s when build/when.browserify.js --no-detect-globals -o build/when.js",
 		"browserify-debug": "browserify -s when build/when.browserify-debug.js --no-detect-globals -o build/when.js"
 	},
-  "browser": {
-    "vertx": false
-  }
+	"browser": {
+		"vertx": false
+	}
 }


### PR DESCRIPTION
TL;DR: this fixes using this module in webpack.

I ran into an error while trying to use this module with [webpack](http://webpack.github.io). Apparently browserify does not recognize the [special require](https://github.com/conradz/when/blob/master/lib/timer.js#L13) that is used to test for vertx support, so it does not attempt to include it in the bundle. Webpack, however, does recognize that syntax and tries to find the `vertx` module, which of course fails. The [proper way](https://github.com/defunctzombie/node-browser-resolve#skip) to exclude a module from being included when targeting the browser is to specify `false` for the module in the `browser` field in the `package.json` file.
