### PR TITLE
Deprecate progress

### DIFF
--- a/lib/decorators/progress.js
+++ b/lib/decorators/progress.js
@@ -8,6 +8,7 @@ define(function() {
 	return function progress(Promise) {
 
 		/**
+		 * @deprecated
 		 * Register a progress handler for this promise
 		 * @param {function} onProgress
 		 * @returns {Promise}

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -60,6 +60,7 @@ define(function() {
 			}
 
 			/**
+			 * @deprecated
 			 * Issue a progress event, notifying all progress listeners
 			 * @param {*} x progress event payload to pass to all listeners
 			 */
@@ -325,7 +326,7 @@ define(function() {
 
 		Handler.prototype.when
 			= Handler.prototype.become
-			= Handler.prototype.notify
+			= Handler.prototype.notify // deprecated
 			= Handler.prototype.fail
 			= Handler.prototype._unreport
 			= Handler.prototype._report
@@ -468,6 +469,9 @@ define(function() {
 			}
 		};
 
+		/**
+		 * @deprecated
+		 */
 		Pending.prototype.notify = function(x) {
 			if(!this.resolved) {
 				tasks.enqueue(new ProgressTask(x, this));
@@ -740,6 +744,9 @@ define(function() {
 			Promise.exitContext();
 		}
 
+		/**
+		 * @deprecated
+		 */
 		function runNotify(f, x, h, receiver, next) {
 			if(typeof f !== 'function') {
 				return next.notify(x);
@@ -774,6 +781,7 @@ define(function() {
 		}
 
 		/**
+		 * @deprecated
 		 * Return f.call(thisArg, x), or if it throws, *return* the exception
 		 */
 		function tryCatchReturn(f, x, thisArg, next) {


### PR DESCRIPTION
Deprecate progress entirely.  Adds `@deprecated` tags in all the related jsdoc, and a section in the docs on one technique that can be used to refactor progress using `promise.tap`.

See #371
