### PR TITLE
Use alternating text node data to avoid MutationObserver polyfill issues

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -23,10 +23,10 @@ define(function(require) {
 		(typeof MutationObserver === 'function' && MutationObserver) ||
 		(typeof WebKitMutationObserver === 'function' && WebKitMutationObserver)) {
 		nextTick = (function (document, MutationObserver) {
-			var scheduled;
-			var el = document.createElement('div');
+			var scheduled, i = 0;
+			var node = document.createTextNode('');
 			var o = new MutationObserver(run);
-			o.observe(el, { attributes: true });
+			o.observe(node, { characterData: true });
 
 			function run() {
 				var f = scheduled;
@@ -36,7 +36,7 @@ define(function(require) {
 
 			return function (f) {
 				scheduled = f;
-				el.setAttribute('class', 'x');
+				node.data = (i ^= 1);
 			};
 		}(document, MutationObs));
 


### PR DESCRIPTION
HT tildeio/rsvp.js#171

Apparently, MO polyfills might not trigger when setting an attribute to the same value.  This change uses a bit flip to alternate between 0 and 1.
