### PR TITLE
Sniff for setTimeout before vertx

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ### 3.5.1
 
 * `when.race` & `Promise.race` now reject with a `TypeError` if you pass something that is not iterable.
+* Improve scheduler compatibility with MutationObserver shims
+* Simplify checks for vert.x environment
 
 ### 3.5.0
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -7,23 +7,25 @@ define(function(require) {
 
 	// Sniff "best" async scheduling option
 	// Prefer process.nextTick or MutationObserver, then check for
-	// vertx and finally fall back to setTimeout
+	// setTimeout, and finally vertx, since its the only env that doesn't
+	// have setTimeout
 
 	/*jshint maxcomplexity:6*/
 	/*global process,document,setTimeout,MutationObserver,WebKitMutationObserver*/
-	var nextTick, MutationObs;
+	var MutationObs;
 
 	if (typeof process !== 'undefined' && process !== null &&
 		typeof process.nextTick === 'function') {
-		nextTick = function(f) {
+		return function (f) {
 			process.nextTick(f);
 		};
+	}
 
-	} else if (MutationObs =
+	if (MutationObs =
 		(typeof MutationObserver === 'function' && MutationObserver) ||
 		(typeof WebKitMutationObserver === 'function' && WebKitMutationObserver)) {
-		nextTick = (function (document, MutationObserver) {
-			var scheduled, i = 0;
+		return (function (document, MutationObserver) {
+			var scheduled;
 			var node = document.createTextNode('');
 			var o = new MutationObserver(run);
 			o.observe(node, { characterData: true });
@@ -34,38 +36,24 @@ define(function(require) {
 				f();
 			}
 
+			var i = 0;
 			return function (f) {
 				scheduled = f;
 				node.data = (i ^= 1);
 			};
 		}(document, MutationObs));
-
-	} else {
-		nextTick = (function(cjsRequire) {
-			var vertx;
-			try {
-				// vert.x 1.x || 2.x
-				vertx = cjsRequire('vertx');
-			} catch (ignore) {}
-
-			if (vertx) {
-				if (typeof vertx.runOnLoop === 'function') {
-					return vertx.runOnLoop;
-				}
-				if (typeof vertx.runOnContext === 'function') {
-					return vertx.runOnContext;
-				}
-			}
-
-			// capture setTimeout to avoid being caught by fake timers
-			// used in time based tests
-			var capturedSetTimeout = setTimeout;
-			return function (t) {
-				capturedSetTimeout(t, 0);
-			};
-		}(require));
 	}
 
-	return nextTick;
+	if (typeof setTimeout !== 'undefined') {
+		var capturedSetTimeout = setTimeout;
+		return function (t) {
+			capturedSetTimeout(t, 0);
+		};
+	}
+
+	var cjsRequire = require;
+	var vertx = cjsRequire('vertx');
+	return vertx.runOnLoop || vertx.runOnContext;
+
 });
 }(typeof define === 'function' && define.amd ? define : function(factory) { module.exports = factory(require); }));

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -5,33 +5,36 @@
 (function(define) { 'use strict';
 define(function(require) {
 	/*global setTimeout,clearTimeout*/
-	var cjsRequire, vertx, setTimer, clearTimer;
+
+	// Sane environments with setTimeout
+	if(typeof setTimeout !== 'undefined') {
+		// NOTE: Truncate decimals to workaround node 0.10.30 bug:
+		// https://github.com/joyent/node/issues/8167
+		return {
+			set: function (f, ms) {
+				return setTimeout(f, ms|0);
+			},
+			clear: function (t) {
+				return clearTimeout(t);
+			}
+		};
+	}
 
 	// Check for vertx environment by attempting to load vertx module.
 	// Doing the check in two steps ensures compatibility with RaveJS,
 	// which will return an empty module when browser: { vertx: false }
 	// is set in package.json
-	cjsRequire = require;
-
-	try {
-		vertx = cjsRequire('vertx');
-	} catch (ignored) {}
+	var cjsRequire = require;
+	var vertx = cjsRequire('vertx');
 
 	// If vertx loaded and has the timer features we expect, try to support it
 	if (vertx && typeof vertx.setTimer === 'function') {
-		setTimer = function (f, ms) { return vertx.setTimer(ms, f); };
-		clearTimer = vertx.cancelTimer;
-	} else {
-		// NOTE: Truncate decimals to workaround node 0.10.30 bug:
-		// https://github.com/joyent/node/issues/8167
-		setTimer = function(f, ms) { return setTimeout(f, ms|0); };
-		clearTimer = function(t) { return clearTimeout(t); };
+		return {
+			set: function (f, ms) {
+				return vertx.setTimer(ms, f);
+			},
+			clear: vertx.cancelTimer
+		};
 	}
-
-	return {
-		set: setTimer,
-		clear: clearTimer
-	};
-
 });
 }(typeof define === 'function' && define.amd ? define : function(factory) { module.exports = factory(require); }));


### PR DESCRIPTION
Check for `setTimeout` before vertx, since vertx is the only env that doesn't have it.  This avoids calling `require` unless we absolutely have to because `setTimeout` is undefined.

Fix #378
