### PR TITLE
Allow passing Arguments object to when/function.apply

### DIFF
--- a/function.js
+++ b/function.js
@@ -33,7 +33,8 @@ define(function(require) {
 	 * @returns {Promise} promise for the return value of func
 	 */
 	function apply(f, args) {
-		return _apply(f, this, args || []);
+		// slice args just in case the caller passed an Arguments instance
+		return _apply(f, this, args == null ? [] : slice.call(args));
 	}
 
 	/**
@@ -60,6 +61,7 @@ define(function(require) {
 	 * @private
 	 */
 	function _apply(f, thisArg, args) {
+		// args MUST be an Array
 		return args.length === 0
 			? attempt.call(thisArg, f)
 			: attempt.apply(thisArg, [f].concat(args));

--- a/test/function-test.js
+++ b/test/function-test.js
@@ -87,6 +87,20 @@ buster.testCase('when/function', {
 			fn.apply(returnsPromise, [5]).then(function(value) {
 				assert.equals(value, 15);
 			}, fail).ensure(done);
+		},
+
+		'should accept Arguments instance': function() {
+			var expected = [1, 2, 3];
+
+			function f() {
+				assert.equals(slice.call(arguments), expected);
+			}
+
+			function run() {
+				return fn.apply(f, arguments);
+			}
+
+			return run.apply(void 0, expected);
 		}
 	},
 


### PR DESCRIPTION
I think this is the smallest possible change to allow Arguments instances to be passed into when/function.apply, compared to #387 whose perf implications aren't clear yet.

cc @phated
