### PR TITLE
Improve map() perf

### DIFF
--- a/lib/decorators/array.js
+++ b/lib/decorators/array.js
@@ -141,17 +141,7 @@ define(function() {
 		 * @returns {Promise}
 		 */
 		function map(promises, f) {
-			if(typeof promises !== 'object') {
-				return toPromise([]);
-			}
-
-			return all(mapArray(function(x, i) {
-				return toPromise(x).fold(mapWithIndex, i);
-			}, promises));
-
-			function mapWithIndex(k, x) {
-				return f(x, k);
-			}
+			return Promise._traverse(f, promises).then(all);
 		}
 
 		/**

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -171,6 +171,7 @@ define(function() {
 
 		Promise.all = all;
 		Promise.race = race;
+		Promise._traverse = traverse;
 
 		/**
 		 * Return a promise that will fulfill when all promises in the
@@ -180,7 +181,14 @@ define(function() {
 		 * @returns {Promise} promise for array of fulfillment values
 		 */
 		function all(promises) {
+			return traverse(void 0, promises);
+		}
+
+		function traverse(f, promises) {
 			/*jshint maxcomplexity:8*/
+
+			var map = typeof f === 'function' ? tryCatch2 : snd;
+
 			var resolver = new Pending();
 			var pending = promises.length >>> 0;
 			var results = new Array(pending);
@@ -201,7 +209,7 @@ define(function() {
 					if (s === 0) {
 						h.fold(settleAt, i, results, resolver);
 					} else if (s > 0) {
-						results[i] = h.value;
+						results[i] = map(f, h.value, i);
 						--pending;
 					} else {
 						resolveAndObserveRemaining(promises, i+1, h, resolver);
@@ -209,7 +217,7 @@ define(function() {
 					}
 
 				} else {
-					results[i] = x;
+					results[i] = map(f, x, i);
 					--pending;
 				}
 			}
@@ -222,7 +230,7 @@ define(function() {
 
 			function settleAt(i, x, resolver) {
 				/*jshint validthis:true*/
-				this[i] = x;
+				this[i] = map(f, x, i);
 				if(--pending === 0) {
 					resolver.become(new Fulfilled(this));
 				}
@@ -770,6 +778,14 @@ define(function() {
 			Promise.exitContext();
 		}
 
+		function tryCatch2(f, a, b) {
+			try {
+				return f(a, b);
+			} catch(e) {
+				return reject(e);
+			}
+		}
+
 		/**
 		 * Return f.call(thisArg, x), or if it throws return a rejected promise for
 		 * the thrown exception
@@ -808,6 +824,10 @@ define(function() {
 		function inherit(Parent, Child) {
 			Child.prototype = objectCreate(Parent.prototype);
 			Child.prototype.constructor = Child;
+		}
+
+		function snd(x, y) {
+			return y;
 		}
 
 		function noop() {}


### PR DESCRIPTION
There was a perf regression in map() in 889d8d2b99d982c9660fab662915ca14fcb1fdfa. This change not only fixes the regression, but improves map() perf well beyond what it was previously by using the new traverse() operations, which is an abstracted version of the very fast all() algorithm.  Now, both all() and map() use traverse().

See examples of the difference here: https://gist.github.com/briancavalier/c5332accfd216bde374d
