### PR TITLE
Improve reduce and reduceRight perf

### DIFF
--- a/lib/decorators/array.js
+++ b/lib/decorators/array.js
@@ -213,9 +213,12 @@ define(function() {
 				return hasArg ? toPromise(arguments[2]) : reject(new TypeError('Cannot reduce empty array with no initial value'));
 			}
 
-			var s = findFirst(a);
-			return hasArg ? runReduce(s, a, f, arguments[2])
-				: runReduce(s + 1, a, f, a[s]);
+			// Skip sparse array holes >:(
+			// jshint curly:false
+			for(var i=0; i<a.length && !(i in a); ++i);
+
+			return hasArg ? runReduce(i, a, f, arguments[2])
+				: runReduce(i + 1, a, f, a[i]);
 		}
 
 		function runReduce(i, a, f, z) {
@@ -245,9 +248,12 @@ define(function() {
 				return hasArg ? toPromise(arguments[2]) : reject(new TypeError('Cannot reduce empty array with no initial value'));
 			}
 
-			var s = findLast(a);
-			return hasArg ? runReduceRight(s, a, f, arguments[2])
-				: runReduceRight(s - 1, a, f, a[s]);
+			// Skip sparse array holes >:(
+			// jshint curly:false
+			for(var i=a.length-1; i>=0 && !(i in a); i--);
+
+			return hasArg ? runReduceRight(i, a, f, arguments[2])
+				: runReduceRight(i - 1, a, f, a[i]);
 		}
 
 		function runReduceRight(i, a, f, z) {
@@ -263,20 +269,6 @@ define(function() {
 			return toPromise(a[i]).fold(function (z, x) {
 				return runReduceRight(i - 1, a, f, f(z, x, i));
 			}, z);
-		}
-
-		function findFirst(a) {
-			for(var i=0; i<a.length; ++i) {
-				if(i in a) { break; }
-			}
-			return i;
-		}
-
-		function findLast(a) {
-			for(var i=a.length-1; i>=0; i--) {
-				if(i in a) { break; }
-			}
-			return i;
 		}
 
 		function mapArray(f, a) {


### PR DESCRIPTION
This uses recursion (which will be trampolined--no call stack concerns), and is 2-3x faster than the previous version which used Array.prototype.reduce.  The code is a lot uglier than it should be due to having to deal with sparse arrays.  At least half the new code is for sparse arrays :( Yet another reason to drop sparse array support in 4.0.

See example of the difference here: https://gist.github.com/briancavalier/e080a3ddced89c1ece84
