### PR TITLE
Improve node.apply/call/lift perf. Reduce mem usage

### DIFF
--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -387,9 +387,7 @@ define(function() {
 		};
 
 		Handler.prototype.fold = function(f, z, c, to) {
-			this.visit(to, function(x) {
-				f.call(c, z, x, this);
-			}, to.reject, to.notify);
+			this.when(new Fold(f, z, c, to));
 		};
 
 		/**
@@ -724,6 +722,28 @@ define(function() {
 				reject(e);
 			}
 		}
+
+		/**
+		 * Fold a handler value with z
+		 * @constructor
+		 */
+		function Fold(f, z, c, to) {
+			this.f = f; this.z = z; this.c = c; this.to = to;
+			this.resolver = failIfRejected;
+			this.receiver = this;
+		}
+
+		Fold.prototype.fulfilled = function(x) {
+			this.f.call(this.c, this.z, x, this.to);
+		};
+
+		Fold.prototype.rejected = function(x) {
+			this.to.reject(x);
+		};
+
+		Fold.prototype.progress = function(x) {
+			this.to.notify(x);
+		};
 
 		// Other helpers
 


### PR DESCRIPTION
There are now zero closures in makePromise, and zero on the hot path
of when/node apply/call/lift.  This improves the perf and reduces mem
usage of promise.fold, and when/node call/apply/lift.
