### PR TITLE
Improve map perf (again)

### DIFF
--- a/lib/decorators/array.js
+++ b/lib/decorators/array.js
@@ -141,7 +141,7 @@ define(function() {
 		 * @returns {Promise}
 		 */
 		function map(promises, f) {
-			return Promise._traverse(f, promises).then(all);
+			return Promise._traverse(f, promises);
 		}
 
 		/**

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -181,20 +181,28 @@ define(function() {
 		 * @returns {Promise} promise for array of fulfillment values
 		 */
 		function all(promises) {
-			return traverse(void 0, promises);
+			return traverseWith(snd, null, promises);
 		}
 
+		/**
+		 * Array<Promise<X>> -> Promise<Array<f(X)>>
+		 * @private
+		 * @param {function} f function to apply to each promise's value
+		 * @param {Array} promises array of promises
+		 * @returns {Promise} promise for transformed values
+		 */
 		function traverse(f, promises) {
-			/*jshint maxcomplexity:8*/
+			return traverseWith(tryCatch2, f, promises);
+		}
 
-			var map = typeof f === 'function' ? tryCatch2 : snd;
+		function traverseWith(tryMap, f, promises) {
+			var handler = typeof f === 'function' ? mapAt : settleAt;
 
 			var resolver = new Pending();
 			var pending = promises.length >>> 0;
 			var results = new Array(pending);
 
-			var i, h, x, s;
-			for (i = 0; i < promises.length; ++i) {
+			for (var i = 0, x; i < promises.length; ++i) {
 				x = promises[i];
 
 				if (x === void 0 && !(i in promises)) {
@@ -202,24 +210,7 @@ define(function() {
 					continue;
 				}
 
-				if (maybeThenable(x)) {
-					h = getHandlerMaybeThenable(x);
-
-					s = h.state();
-					if (s === 0) {
-						h.fold(settleAt, i, results, resolver);
-					} else if (s > 0) {
-						results[i] = map(f, h.value, i);
-						--pending;
-					} else {
-						resolveAndObserveRemaining(promises, i+1, h, resolver);
-						break;
-					}
-
-				} else {
-					results[i] = map(f, x, i);
-					--pending;
-				}
+				traverseAt(promises, handler, i, x, resolver);
 			}
 
 			if(pending === 0) {
@@ -228,12 +219,33 @@ define(function() {
 
 			return new Promise(Handler, resolver);
 
+			function mapAt(i, x, resolver) {
+				traverseAt(promises, settleAt, i, tryMap(f, x, i), resolver);
+			}
+
 			function settleAt(i, x, resolver) {
-				/*jshint validthis:true*/
-				this[i] = map(f, x, i);
+				results[i] = x;
 				if(--pending === 0) {
-					resolver.become(new Fulfilled(this));
+					resolver.become(new Fulfilled(results));
 				}
+			}
+		}
+
+		function traverseAt(promises, handler, i, x, resolver) {
+			if (maybeThenable(x)) {
+				var h = getHandlerMaybeThenable(x);
+				var s = h.state();
+
+				if (s === 0) {
+					h.fold(handler, i, void 0, resolver);
+				} else if (s > 0) {
+					handler(i, h.value, resolver);
+				} else {
+					resolveAndObserveRemaining(promises, i+1, h, resolver);
+				}
+
+			} else {
+				handler(i, x, resolver);
 			}
 		}
 


### PR DESCRIPTION
This change increases the performance of map by 10x or more for large arrays, and significantly decreases mem usage.  Map operates in a single pass now, instead of 2 passes--1 to map, 1 to await with all().

The size diff is negligible--around 20 bytes min+gzip. The perf impact on all() is also negligible--less than 1%.
