### PR TITLE
Improve reduce() and lift() perf.

### DIFF
--- a/callbacks.js
+++ b/callbacks.js
@@ -16,6 +16,10 @@ define(function(require) {
 	var _liftAll = require('./lib/liftAll');
 	var slice = Array.prototype.slice;
 
+	var makeApply = require('./lib/apply');
+	var _apply = makeApply(Promise, dispatch);
+	var tryCatchResolve = makeApply.tryCatchResolve;
+
 	return {
 		lift: lift,
 		liftAll: liftAll,
@@ -62,15 +66,9 @@ define(function(require) {
 	 * Apply helper that allows specifying thisArg
 	 * @private
 	 */
-	function _apply(asyncFunction, thisArg, extraAsyncArgs) {
-		return Promise.all(extraAsyncArgs).then(function(args) {
-			var p = Promise._defer();
-			args.push(alwaysUnary(p._handler.resolve, p._handler),
-				alwaysUnary(p._handler.reject, p._handler));
-			asyncFunction.apply(thisArg, args);
-
-			return p;
-		});
+	function dispatch(f, thisArg, args, h) {
+		args.push(alwaysUnary(h.resolve, h), alwaysUnary(h.reject, h));
+		tryCatchResolve(f, thisArg, args, h);
 	}
 
 	/**

--- a/function.js
+++ b/function.js
@@ -14,6 +14,7 @@ define(function(require) {
 	var when = require('./when');
 	var attempt = when['try'];
 	var _liftAll = require('./lib/liftAll');
+	var _apply = require('./lib/apply')(when.Promise);
 	var slice = Array.prototype.slice;
 
 	return {
@@ -54,17 +55,6 @@ define(function(require) {
 		return function() {
 			return _apply(f, this, args.concat(slice.call(arguments)));
 		};
-	}
-
-	/**
-	 * Apply helper that allows specifying thisArg
-	 * @private
-	 */
-	function _apply(f, thisArg, args) {
-		// args MUST be an Array
-		return args.length === 0
-			? attempt.call(thisArg, f)
-			: attempt.apply(thisArg, [f].concat(args));
 	}
 
 	/**

--- a/lib/apply.js
+++ b/lib/apply.js
@@ -1,0 +1,55 @@
+/** @license MIT License (c) copyright 2010-2014 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+(function(define) { 'use strict';
+define(function() {
+
+	makeApply.tryCatchResolve = tryCatchResolve;
+
+	return makeApply;
+
+	function makeApply(Promise, call) {
+		if(arguments.length < 2) {
+			call = tryCatchResolve;
+		}
+
+		return apply;
+
+		function apply(f, thisArg, args) {
+			var p = Promise._defer();
+			var l = args.length;
+			var params = new Array(l);
+			callAndResolve({ f:f, thisArg:thisArg, args:args, params:params, i:l-1, call:call }, p._handler);
+
+			return p;
+		}
+
+		function callAndResolve(c, h) {
+			if(c.i < 0) {
+				return call(c.f, c.thisArg, c.params, h);
+			}
+
+			var handler = Promise._handler(c.args[c.i]);
+			handler.fold(callAndResolveNext, c, void 0, h);
+		}
+
+		function callAndResolveNext(c, x, h) {
+			c.params[c.i] = x;
+			c.i -= 1;
+			callAndResolve(c, h);
+		}
+	}
+
+	function tryCatchResolve(f, thisArg, args, resolver) {
+		try {
+			resolver.resolve(f.apply(thisArg, args));
+		} catch(e) {
+			resolver.reject(e);
+		}
+	}
+
+});
+}(typeof define === 'function' && define.amd ? define : function(factory) { module.exports = factory(); }));
+
+

--- a/lib/decorators/array.js
+++ b/lib/decorators/array.js
@@ -6,14 +6,16 @@
 define(function(require) {
 
 	var state = require('../state');
+	var applier = require('../apply');
 
 	return function array(Promise) {
 
-		var arrayReduce = Array.prototype.reduce;
-
+		var applyFold = applier(Promise, dispatch);
 		var toPromise = Promise.resolve;
-		var reject = Promise.reject;
 		var all = Promise.all;
+
+		var ar = Array.prototype.reduce;
+		var arr = Array.prototype.reduceRight;
 
 		// Additional array combinators
 
@@ -129,7 +131,7 @@ define(function(require) {
 		 * @returns {Number} actual count of items being raced
 		 */
 		function initRace(promises, resolve, reject, notify) {
-			return arrayReduce.call(promises, function(pending, p) {
+			return ar.call(promises, function(pending, p) {
 				toPromise(p).then(resolve, reject, notify);
 				return pending + 1;
 			}, 0);
@@ -192,77 +194,45 @@ define(function(require) {
 		}
 
 		/**
-		 * Reduce an array of promises and values
-		 * @param {Array} a array of promises
+		 * Traditional reduce function, similar to `Array.prototype.reduce()`, but
+		 * input may contain promises and/or values, and reduceFunc
+		 * may return either a value or a promise, *and* initialValue may
+		 * be a promise for the starting value.
+		 * @param {Array|Promise} promises array or promise for an array of anything,
+		 *      may contain a mix of promises and values.
 		 * @param {function(accumulated:*, x:*, index:Number):*} f reduce function
-		 * @returns {Promise} promise for reduced value
+		 * @returns {Promise} that will resolve to the final reduced value
 		 */
-		function reduce(a, f) {
-			var hasArg = arguments.length > 2;
-			if((a.length>>>0) === 0) {
-				return hasArg ? toPromise(arguments[2]) : reject(new TypeError('Cannot reduce empty array with no initial value'));
-			}
-
-			// Skip sparse array holes >:(
-			// jshint curly:false
-			for(var i=0; i<a.length && !(i in a); ++i);
-
-			return hasArg ? runReduce(i, a, f, arguments[2])
-				: runReduce(i + 1, a, f, a[i]);
-		}
-
-		function runReduce(i, a, f, z) {
-			if (i === a.length) {
-				return z;
-			}
-
-			var x = a[i];
-			if(x === void 0 && !(i in a)) {
-				return runReduce(i + 1, a, f, z);
-			}
-
-			return toPromise(a[i]).fold(function (z, x) {
-				return runReduce(i + 1, a, f, f(z, x, i));
-			}, z);
+		function reduce(promises, f /*, initialValue */) {
+			return arguments.length > 2 ? ar.call(promises, liftCombine(f), arguments[2])
+					: ar.call(promises, liftCombine(f));
 		}
 
 		/**
-		 * Reduce an array of promises and values from the right
-		 * @param {Array} a array of promises
+		 * Traditional reduce function, similar to `Array.prototype.reduceRight()`, but
+		 * input may contain promises and/or values, and reduceFunc
+		 * may return either a value or a promise, *and* initialValue may
+		 * be a promise for the starting value.
+		 * @param {Array|Promise} promises array or promise for an array of anything,
+		 *      may contain a mix of promises and values.
 		 * @param {function(accumulated:*, x:*, index:Number):*} f reduce function
-		 * @returns {Promise} promise for reduced value
+		 * @returns {Promise} that will resolve to the final reduced value
 		 */
-		function reduceRight(a, f) {
-			var hasArg = arguments.length > 2;
-			if((a.length>>>0) === 0) {
-				return hasArg ? toPromise(arguments[2]) : reject(new TypeError('Cannot reduce empty array with no initial value'));
-			}
-
-			// Skip sparse array holes >:(
-			// jshint curly:false
-			for(var i=a.length-1; i>=0 && !(i in a); i--);
-
-			return hasArg ? runReduceRight(i, a, f, arguments[2])
-				: runReduceRight(i - 1, a, f, a[i]);
+		function reduceRight(promises, f /*, initialValue */) {
+			return arguments.length > 2 ? arr.call(promises, liftCombine(f), arguments[2])
+					: arr.call(promises, liftCombine(f));
 		}
 
-		function runReduceRight(i, a, f, z) {
-			if (i < 0) {
-				return z;
-			}
+		function liftCombine(f) {
+			return function(z, x, i) {
+				return applyFold(f, void 0, [z,x,i]);
+			};
+		}
 
-			var x = a[i];
-			if(x === void 0 && !(i in a)) {
-				return runReduceRight(i - 1, a, f, z);
-			}
-
-			return toPromise(a[i]).fold(function (z, x) {
-				return runReduceRight(i - 1, a, f, f(z, x, i));
-			}, z);
+		function dispatch(f, _, args, resolver) {
+			resolver.resolve(f(args[0], args[1], args[2]));
 		}
 	};
-
-
 
 });
 }(typeof define === 'function' && define.amd ? define : function(factory) { module.exports = factory(require); }));


### PR DESCRIPTION
Extract fast argument traversal to lib/apply, use in lift/call/apply variants, and in reduce/reduceRight.
