### PR TITLE
Improve any and some perf

### DIFF
--- a/lib/decorators/array.js
+++ b/lib/decorators/array.js
@@ -51,21 +51,53 @@ define(function(require) {
 		 * @returns {Promise} promise for the first fulfilled value
 		 */
 		function any(promises) {
-			return new Promise(function(resolve, reject) {
-				var errors = [];
-				var pending = initRace(promises, resolve, handleReject);
+			var p = Promise._defer();
+			var resolver = p._handler;
+			var l = promises.length>>>0;
 
-				if(pending === 0) {
-					reject(new RangeError('any() input must not be empty'));
+			var pending = l;
+			var errors = [];
+
+			for (var h, x, i = 0; i < l; ++i) {
+				x = promises[i];
+				if(x === void 0 && !(i in promises)) {
+					--pending;
+					continue;
 				}
 
-				function handleReject(e) {
-					errors.push(e);
-					if(--pending === 0) {
-						reject(errors);
-					}
+				h = Promise._handler(x);
+				if(h.state() > 0) {
+					resolver.become(h);
+					Promise._visitRemaining(promises, i, h);
+					break;
+				} else {
+					h.visit(resolver, handleFulfill, handleReject);
 				}
-			});
+			}
+
+			if(pending === 0) {
+				resolver.reject(new RangeError('any(): array must not be empty'));
+			}
+
+			return p;
+
+			function handleFulfill(x) {
+				/*jshint validthis:true*/
+				errors = null;
+				this.resolve(x); // this === resolver
+			}
+
+			function handleReject(e) {
+				/*jshint validthis:true*/
+				if(this.resolved) { // this === resolver
+					return;
+				}
+
+				errors.push(e);
+				if(--pending === 0) {
+					this.reject(errors);
+				}
+			}
 		}
 
 		/**
@@ -81,60 +113,76 @@ define(function(require) {
 		 * @deprecated
 		 */
 		function some(promises, n) {
-			return new Promise(function(resolve, reject, notify) {
-				var results = [];
-				var errors = [];
-				var nReject;
-				var nFulfill = initRace(promises, handleResolve, handleReject, notify);
+			/*jshint maxcomplexity:7*/
+			var p = Promise._defer();
+			var resolver = p._handler;
 
-				n = Math.max(n, 0);
-				nReject = (nFulfill - n + 1);
-				nFulfill = Math.min(n, nFulfill);
+			var results = [];
+			var errors = [];
 
-				if(n > nFulfill) {
-					reject(new RangeError('some() input must contain at least '
-						+ n + ' element(s), but had ' + nFulfill));
-				} else if(nFulfill === 0) {
-					resolve(results);
+			var l = promises.length>>>0;
+			var nFulfill = 0;
+			var nReject;
+			var x, i; // reused in both for() loops
+
+			// First pass: count actual array items
+			for(i=0; i<l; ++i) {
+				x = promises[i];
+				if(x === void 0 && !(i in promises)) {
+					continue;
+				}
+				++nFulfill;
+			}
+
+			// Compute actual goals
+			n = Math.max(n, 0);
+			nReject = (nFulfill - n + 1);
+			nFulfill = Math.min(n, nFulfill);
+
+			if(n > nFulfill) {
+				resolver.reject(new RangeError('some(): array must contain at least '
+				+ n + ' item(s), but had ' + nFulfill));
+			} else if(nFulfill === 0) {
+				resolver.resolve(results);
+			}
+
+			// Second pass: observe each array item, make progress toward goals
+			for(i=0; i<l; ++i) {
+				x = promises[i];
+				if(x === void 0 && !(i in promises)) {
+					continue;
 				}
 
-				function handleResolve(x) {
-					if(nFulfill > 0) {
-						--nFulfill;
-						results.push(x);
+				Promise._handler(x).visit(resolver, fulfill, reject, resolver.notify);
+			}
 
-						if(nFulfill === 0) {
-							resolve(results);
-						}
-					}
+			return p;
+
+			function fulfill(x) {
+				/*jshint validthis:true*/
+				if(this.resolved) { // this === resolver
+					return;
 				}
 
-				function handleReject(e) {
-					if(nReject > 0) {
-						--nReject;
-						errors.push(e);
-
-						if(nReject === 0) {
-							reject(errors);
-						}
-					}
+				results.push(x);
+				if(--nFulfill === 0) {
+					errors = null;
+					this.resolve(results);
 				}
-			});
-		}
+			}
 
-		/**
-		 * Initialize a race observing each promise in the input promises
-		 * @param {Array} promises
-		 * @param {function} resolve
-		 * @param {function} reject
-		 * @param {?function=} notify
-		 * @returns {Number} actual count of items being raced
-		 */
-		function initRace(promises, resolve, reject, notify) {
-			return ar.call(promises, function(pending, p) {
-				toPromise(p).then(resolve, reject, notify);
-				return pending + 1;
-			}, 0);
+			function reject(e) {
+				/*jshint validthis:true*/
+				if(this.resolved) { // this === resolver
+					return;
+				}
+
+				errors.push(e);
+				if(--nReject === 0) {
+					results = null;
+					this.reject(errors);
+				}
+			}
 		}
 
 		/**

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -202,7 +202,7 @@ define(function() {
 			var pending = promises.length >>> 0;
 			var results = new Array(pending);
 
-			for (var i = 0, x; i < promises.length; ++i) {
+			for (var i = 0, x; i < promises.length && !resolver.resolved; ++i) {
 				x = promises[i];
 
 				if (x === void 0 && !(i in promises)) {
@@ -220,7 +220,9 @@ define(function() {
 			return new Promise(Handler, resolver);
 
 			function mapAt(i, x, resolver) {
-				traverseAt(promises, settleAt, i, tryMap(f, x, i), resolver);
+				if(!resolver.resolved) {
+					traverseAt(promises, settleAt, i, tryMap(f, x, i), resolver);
+				}
 			}
 
 			function settleAt(i, x, resolver) {
@@ -241,26 +243,31 @@ define(function() {
 				} else if (s > 0) {
 					handler(i, h.value, resolver);
 				} else {
-					resolveAndObserveRemaining(promises, i+1, h, resolver);
+					resolver.become(h);
+					visitRemaining(promises, i+1, h);
 				}
-
 			} else {
 				handler(i, x, resolver);
 			}
 		}
 
-		function resolveAndObserveRemaining(promises, start, handler, resolver) {
-			resolver.become(handler);
+		Promise._visitRemaining = visitRemaining;
+		function visitRemaining(promises, start, handler) {
+			for(var i=start; i<promises.length; ++i) {
+				markAsHandled(getHandler(promises[i]), handler);
+			}
+		}
 
-			var i, h, x;
-			for(i=start; i<promises.length; ++i) {
-				x = promises[i];
-				if(maybeThenable(x)) {
-					h = getHandlerMaybeThenable(x);
-					if(h !== handler) {
-						h.visit(h, void 0, h._unreport);
-					}
-				}
+		function markAsHandled(h, handler) {
+			if(h === handler) {
+				return;
+			}
+
+			var s = h.state();
+			if(s === 0) {
+				h.visit(h, void 0, h._unreport);
+			} else if(s < 0) {
+				h._unreport();
 			}
 		}
 
@@ -301,11 +308,12 @@ define(function() {
 
 				h = getHandler(x);
 				if(h.state() !== 0) {
-					resolveAndObserveRemaining(promises, i+1, h, resolver);
+					resolver.become(h);
+					visitRemaining(promises, i+1, h);
 					break;
+				} else {
+					h.visit(resolver, resolver.resolve, resolver.reject);
 				}
-
-				h.visit(resolver, resolver.resolve, resolver.reject);
 			}
 			return new Promise(Handler, resolver);
 		}


### PR DESCRIPTION
They now use similar patterns to _traverse.  Also: fix `_traverse` fast-path on first rejection. Simplify `resolveAndObserveRemaining` to `visitRemaining` and expose as private API to allow other array combinators to take advantage of it.
