### PR TITLE
Ensure exceptions can't break reduce

### DIFF
--- a/lib/decorators/array.js
+++ b/lib/decorators/array.js
@@ -10,7 +10,7 @@ define(function(require) {
 
 	return function array(Promise) {
 
-		var applyFold = applier(Promise, dispatch);
+		var applyFold = applier(Promise);
 		var toPromise = Promise.resolve;
 		var all = Promise.all;
 
@@ -275,10 +275,6 @@ define(function(require) {
 			return function(z, x, i) {
 				return applyFold(f, void 0, [z,x,i]);
 			};
-		}
-
-		function dispatch(f, _, args, resolver) {
-			resolver.resolve(f(args[0], args[1], args[2]));
 		}
 	};
 

--- a/test/sequence-test.js
+++ b/test/sequence-test.js
@@ -4,6 +4,8 @@ var assert = buster.assert;
 var when = require('../when');
 var sequence = require('../sequence');
 
+var sentinel = { value: 'sentinel' };
+
 function createTask(y) {
 	return function() {
 		return y;
@@ -52,5 +54,15 @@ buster.testCase('when/sequence', {
 
 		expected = [when(1), when(2), when(3)];
 		return sequence.apply(null, [tasks].concat(expected)).ensure(done);
+	},
+
+	'should reject if task throws': function() {
+		return sequence([function () {
+			return 1;
+		}, function () {
+			throw sentinel;
+		}])['catch'](function (e) {
+			assert.same(e, sentinel);
+		});
 	}
 });


### PR DESCRIPTION
This removes the fast dispatcher that was tailored for reduce in favor of the default, safer dispatcher.  There is a tiny perf hit, since the default uses a try/catch and `apply()`.  Unit test derived from @benurb's example in #401.

Fix #401
