### PR TITLE
Workaround v8 optimizer bug

### DIFF
--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -124,10 +124,10 @@ define(function() {
 		 * this promise's fulfillment.
 		 * @param {function=} onFulfilled fulfillment handler
 		 * @param {function=} onRejected rejection handler
-		 * @deprecated @param {function=} onProgress progress handler
+		 * @param {function=} onProgress @deprecated progress handler
 		 * @return {Promise} new promise
 		 */
-		Promise.prototype.then = function(onFulfilled, onRejected) {
+		Promise.prototype.then = function(onFulfilled, onRejected, onProgress) {
 			var parent = this._handler;
 			var state = parent.join().state();
 
@@ -140,8 +140,7 @@ define(function() {
 			var p = this._beget();
 			var child = p._handler;
 
-			parent.chain(child, parent.receiver, onFulfilled, onRejected,
-					arguments.length > 2 ? arguments[2] : void 0);
+			parent.chain(child, parent.receiver, onFulfilled, onRejected, onProgress);
 
 			return p;
 		};
@@ -162,10 +161,13 @@ define(function() {
 		 * @returns {Promise}
 		 */
 		Promise.prototype._beget = function() {
-			var parent = this._handler;
-			var child = new Pending(parent.receiver, parent.join().context);
-			return new this.constructor(Handler, child);
+			return begetFrom(this._handler, this.constructor);
 		};
+
+		function begetFrom(parent, Promise) {
+			var child = new Pending(parent.receiver, parent.join().context);
+			return new Promise(Handler, child);
+		}
 
 		// Array combinators
 

--- a/when.js
+++ b/when.js
@@ -80,15 +80,13 @@ define(function (require) {
 	 *   value of callback or errback or the completion value of promiseOrValue if
 	 *   callback and/or errback is not supplied.
 	 */
-	function when(x, onFulfilled, onRejected) {
+	function when(x, onFulfilled, onRejected, onProgress) {
 		var p = Promise.resolve(x);
-		if(arguments.length < 2) {
+		if (arguments.length < 2) {
 			return p;
 		}
 
-		return arguments.length > 3
-			? p.then(onFulfilled, onRejected, arguments[3])
-			: p.then(onFulfilled, onRejected);
+		return p.then(onFulfilled, onRejected, onProgress);
 	}
 
 	/**


### PR DESCRIPTION
After some testing by @anodynos, @spion, and myself, we found a few
things other than adding an empty try/finally in _beget that seem to
workaround the v8 bug.  One is to do away with the arguments + ternary
operator deref in then(), in favor of reinstating the onProgress
parameter for now.

The other is to split _beget and delegate its work to a helper function.

After making that change, I realized that there's no need for a
similar arguments+ternary check in the main when() function, if we
reinstate the parameter there as well.  So, I changed that one too.

Close #403 
Close #345
