### PR TITLE
Deal with predicates that modify the original array.

### DIFF
--- a/lib/decorators/array.js
+++ b/lib/decorators/array.js
@@ -16,6 +16,7 @@ define(function(require) {
 
 		var ar = Array.prototype.reduce;
 		var arr = Array.prototype.reduceRight;
+		var slice = Array.prototype.slice;
 
 		// Additional array combinators
 
@@ -206,8 +207,9 @@ define(function(require) {
 		 *  for which predicate returned truthy.
 		 */
 		function filter(promises, predicate) {
-			return Promise._traverse(predicate, promises).then(function(keep) {
-				return filterSync(promises, keep);
+			var a = slice.call(promises);
+			return Promise._traverse(predicate, a).then(function(keep) {
+				return filterSync(a, keep);
 			});
 		}
 
@@ -224,6 +226,7 @@ define(function(require) {
 			return filtered;
 
 		}
+
 		/**
 		 * Return a promise that will always fulfill with an array containing
 		 * the outcome states of all input promises.  The returned promise

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -73,6 +73,24 @@ buster.testCase('when.filter', {
 			function(e) {
 				assert.same(e, sentinel);
 			});
+	},
+
+	'should match Array.prototype.filter behavior when predicate modifies array': function() {
+		// Test to match Array.prototype.filter behavior
+		var a = [1, 2, 3, 4];
+		var b = a.slice();
+		var expected = b.filter(makePredicate(b));
+
+		function makePredicate(a) {
+			return function (n, i){
+				a[i] = 'fail';
+				return n % 2 === 0;
+			};
+		}
+
+		return when.filter(a, makePredicate(a)).then(function(results) {
+			assert.equals(results, expected);
+		});
 	}
 
 });


### PR DESCRIPTION
Allow filter to match Array.prototype.filter behavior when input array
is modified by the filter predicate.

Unit test fails for 3.6.1. Passes as of cca3254

Fix #400 
