### PR TITLE
Avoid inter-lib, recursive nextTick warning on node 0.10

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -2,7 +2,7 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-/*global process,document,setTimeout,clearTimeout,MutationObserver,WebKitMutationObserver*/
+/*global process,document,setTimeout,clearTimeout,setImmediate,MutationObserver,WebKitMutationObserver*/
 (function(define) { 'use strict';
 define(function(require) {
 	/*jshint maxcomplexity:6*/
@@ -22,7 +22,7 @@ define(function(require) {
 
 	// Detect specific env
 	if (isNode()) { // Node
-		asap = function (f) { return process.nextTick(f); };
+		asap = initNode(process);
 
 	} else if (MutationObs = hasMutationObserver()) { // Modern browser
 		asap = initMutationObserver(MutationObs);
@@ -44,6 +44,17 @@ define(function(require) {
 	function isNode () {
 		return typeof process !== 'undefined' && process !== null &&
 			typeof process.nextTick === 'function';
+	}
+
+	function initNode(process) {
+		// See https://github.com/cujojs/when/issues/410
+		// Use setImmediate in node 0.10 to avoid inter-library, recursive
+		// nextTick deprecation warning.
+		if(/^0\.10\./.test(process.versions.node)) {
+			return function nodeSetImmediate(f) { setImmediate(f); };
+		}
+
+		return function nodeNextTick(f) { return process.nextTick(f); };
 	}
 
 	function hasMutationObserver () {

--- a/lib/env.js
+++ b/lib/env.js
@@ -50,7 +50,7 @@ define(function(require) {
 		// See https://github.com/cujojs/when/issues/410
 		// Use setImmediate in node 0.10 to avoid inter-library, recursive
 		// nextTick deprecation warning.
-		if(/^0\.10\./.test(process.versions.node)) {
+		if(process.versions.node.slice(0, 5) === '0.10.') {
 			return function nodeSetImmediate(f) { setImmediate(f); };
 		}
 


### PR DESCRIPTION
See #410 

Use `setImmediate` on node 0.10 to avoid hitting its max nested tick limit warning.

We've not had any direct reports from a when.js user who has encountered this.  However, the test case from RSVP is generic, so it's pretty clear that this could happen to any set of interleaving promise libs.

It's a shame that this requires a version check :(

cc @stefanpenner

Fix #410 
