### PR TITLE
Fix unhandled rejection reporting for null errors

### DIFF
--- a/lib/decorators/unhandledRejection.js
+++ b/lib/decorators/unhandledRejection.js
@@ -75,7 +75,7 @@ define(function(require) {
 	};
 
 	function formatError(e) {
-		var s = typeof e === 'object' && e.stack ? e.stack : formatObject(e);
+		var s = typeof e === 'object' && e !== null && e.stack ? e.stack : formatObject(e);
 		return e instanceof Error ? s : s + ' (WARNING: non-Error used)';
 	}
 


### PR DESCRIPTION
In case promise is rejected with a 'null' and unhadled rejection is reported check for error type fails in 'formatError' method. The reason for it is that 'typeof null' is also an 'object' (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof). 

Therefore an additional check for 'e' to also not be a 'null' is added to 'formatError' method code.
