### PR TITLE
Initial prototype for AbortablePromise

### DIFF
--- a/lib/makeAbortablePromise.js
+++ b/lib/makeAbortablePromise.js
@@ -1,0 +1,103 @@
+/** @license MIT License (c) copyright 2010-2014 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+(function(define) { 'use strict';
+define(function() {
+
+	return function makeAbortablePromise(Promise) {
+
+		function AbortablePromise(resolver) {
+			Promise.call(this, makeAbortableResolver(resolver, this));
+		}
+
+		AbortablePromise.prototype = Object.create(Promise.prototype);
+
+		// Set constructor so that Promise.prototype.then will work
+		AbortablePromise.prototype.constructor = AbortablePromise;
+
+		AbortablePromise.prototype.then = function(f, r, p) {
+			var child = Promise.prototype.then.call(this, f, r, p);
+
+			// Propagate abort to child via handler
+			child._handler.abort = this._handler.abort;
+
+			return child;
+		};
+
+		AbortablePromise.prototype.abort = function() {
+			var handler = this._handler;
+
+			if (typeof handler.abort !== 'function') {
+				return;
+			}
+
+			// Detach abort so it can only be called once
+			var fn = handler.abort;
+			handler.abort = null;
+
+			try {
+				// aborter may return a promise to control the outcome of
+				// the abort process.
+				var abortResult = fn.apply(void 0, arguments);
+				handler.resolve(abortResult);
+
+				// Ensure return value is always a promise, specifically a
+				// non-abortable promise
+				return Promise.resolve(abortResult);
+			} catch (e) {
+				console.error(e.stack);
+				handler.reject(e);
+			}
+		};
+
+		function makeAbortableResolver(task, abortablePromise) {
+			return function() {
+				runAbortableTask(task, abortablePromise._handler);
+			};
+		}
+
+		function runAbortableTask(task, handler) {
+			// Make rejecting be the default abort behavior.
+			handler.abort = defaultAbort;
+
+			// Resolver may return an aborter function
+			var result = task(abortableResolve, abortableReject);
+
+			// If it did, stash it on the handler
+			if(typeof result === 'function') {
+				handler.abort = result;
+			}
+
+			function abortableResolve(x) {
+				// If x is also an abortable promise, propagate its abort function
+				// to handler.
+				handler.abort = getAbort(x);
+				handler.resolve(x);
+			}
+
+			function abortableReject(e) {
+				// Always disable abort upon reject
+				handler.abort = null;
+				handler.reject(e);
+			}
+
+			function defaultAbort(x) {
+				handler.reject(x);
+			}
+		}
+
+		return AbortablePromise;
+	};
+
+	function getAbort (x) {
+		// Make a reasonable attempt to recognize abortable thenables
+		return maybeThenable(x) ? x.abort : null;
+	}
+
+	function maybeThenable(x) {
+		return (typeof x === 'object' || typeof x === 'function') && x !== null;
+	}
+
+});
+}(typeof define === 'function' && define.amd ? define : function(factory) { module.exports = factory(); }));

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -23,24 +23,26 @@ define(function() {
 		 * @name Promise
 		 */
 		function Promise(resolver, handler) {
-			this._handler = resolver === Handler ? handler : init(resolver);
+			if(resolver === Handler) {
+				this._handler = handler;
+			} else {
+				this._handler = new Pending();
+				init(resolver, this._handler);
+			}
 		}
 
 		/**
 		 * Run the supplied resolver
 		 * @param resolver
+		 * @param handler
 		 * @returns {Pending}
 		 */
-		function init(resolver) {
-			var handler = new Pending();
-
+		function init(resolver, handler) {
 			try {
 				resolver(promiseResolve, promiseReject, promiseNotify);
 			} catch (e) {
 				promiseReject(e);
 			}
-
-			return handler;
 
 			/**
 			 * Transition from pre-resolution state to post-resolution state, notifying


### PR DESCRIPTION
**DO NOT MERGE**: This is a prototype of an AbortablePromise, for discussion and iteration to prove the idea.

This adds a new AbortablePromise subtype that has an `abort()` method which can send a signal from a consumer back toward the root of the promise graph to the producer indicating that the consumer wishes to abort the task that is computing the promise's value.  This can be used to stop long-running or resource-consuming tasks when a consumer decides it no longer wants the result.  For example: XHR request.
#### Initial prototype

The initial implementation isn't ideal but is headed in the right direction.  The abort functionality should be provided at the handler level, and a thin wrapper for it provided at the AbortablePromise.prototype level.  The initial prototype does that, but by stashing an additional property on the existing handler.  Ideally, we would have a new type of handler, eg AbortableHandler, that provided the functionality.
#### Open questions

This prototype doesn't provide `AbortablePromise.resolve` or `AbortablePromise.reject`.  I believe that it will need to.  The reason is for API consistency: APIs that return `AbortablePromise` may need to return resolved and/or rejected promises, and returning `Promise.resolve/reject` would return a promise without an `abort()` method, which would break callers of those APIs.

`Promise.all` and `Promise.race` may also need abortable analogs that return an `AbortablePromise`.  They would also need to handle abortable _thenables_ in their input arrays, aborting them when the returned promise is aborted.  That may be a slippery slope into needing to detect `abort` in many more places (when.map, when.filter, when.reduce, etc etc etc).

cc @mjackson
