### PR TITLE
Add alternative instructions to browserify section

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -76,6 +76,11 @@ Since when.js primarily targets modular environments, it doesn't export to the g
   1. `when` will be available as `window.when`
   1. Other modules will be available as sub-objects/functions, e.g. `window.when.fn.lift`, `window.when.sequence`.  See the [full sub-namespace list in the browserify build file](../build/when.browserify.js)
 
+Or if you want to do this from your project's package.json:
+
+1. `npm install cujojs/when browserify --save`
+1. Add `cd node_modules/when && npm run browserify` to your postinstall script in package.json
+
 #### Web Worker (via browserify)
 
 Similarly to browser global environments:


### PR DESCRIPTION
This is a suggestion for https://github.com/cujojs/when/issues/349#issuecomment-68289062 .  Feel free to reject this PR if you don't agree with these changes, they're just a suggestion.

The goal of this change is to make sure someone can start developing with when as quickly as possible.  Especially when prototyping a new project I find it useful to keep things simple at first (which is a bunch of &lt;script&gt; tags), and graduate to using something like cujojs/curl or requirejs when the project matures.