### PR TITLE
Add global window and process events for unhandled rejections

### DIFF
--- a/lib/decorators/unhandledRejection.js
+++ b/lib/decorators/unhandledRejection.js
@@ -9,6 +9,7 @@ define(function(require) {
 	var format = require('../format');
 
 	return function unhandledRejection(Promise) {
+
 		var logError = noop;
 		var logInfo = noop;
 		var localConsole;

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -8,6 +8,7 @@ define(function() {
 	return function makePromise(environment) {
 
 		var tasks = environment.scheduler;
+		var emitRejection = initEmitRejection();
 
 		var objectCreate = Object.create ||
 			function(proto) {
@@ -637,6 +638,8 @@ define(function() {
 		};
 
 		Rejected.prototype.fail = function(context) {
+			this.reported = true;
+			emitRejection('unhandledRejection', this);
 			Promise.onFatalRejection(this, context === void 0 ? this.context : context);
 		};
 
@@ -646,9 +649,10 @@ define(function() {
 		}
 
 		ReportTask.prototype.run = function() {
-			if(!this.rejection.handled) {
+			if(!this.rejection.handled && !this.rejection.reported) {
 				this.rejection.reported = true;
-				Promise.onPotentiallyUnhandledRejection(this.rejection, this.context);
+				emitRejection('unhandledRejection', this.rejection) ||
+					Promise.onPotentiallyUnhandledRejection(this.rejection, this.context);
 			}
 		};
 
@@ -658,14 +662,14 @@ define(function() {
 
 		UnreportTask.prototype.run = function() {
 			if(this.rejection.reported) {
-				Promise.onPotentiallyUnhandledRejectionHandled(this.rejection);
+				emitRejection('rejectionHandled', this.rejection) ||
+					Promise.onPotentiallyUnhandledRejectionHandled(this.rejection);
 			}
 		};
 
 		// Unhandled rejection hooks
 		// By default, everything is a noop
 
-		// TODO: Better names: "annotate"?
 		Promise.createContext
 			= Promise.enterContext
 			= Promise.exitContext
@@ -877,6 +881,45 @@ define(function() {
 		}
 
 		function noop() {}
+
+		function initEmitRejection() {
+			/*global process, self, CustomEvent*/
+			if(typeof process !== 'undefined' && process !== null
+				&& typeof process.emit === 'function') {
+				// Returning falsy here means to call the default
+				// onPotentiallyUnhandledRejection API.  This is safe even in
+				// browserify since process.emit always returns falsy in browserify:
+				// https://github.com/defunctzombie/node-process/blob/master/browser.js#L40-L46
+				return function(type, rejection) {
+					return type === 'unhandledRejection'
+						? process.emit(type, rejection.value, rejection)
+						: process.emit(type, rejection);
+				};
+			} else if(typeof self !== 'undefined' && typeof CustomEvent === 'function') {
+				return (function(noop, self, CustomEvent) {
+					var hasCustomEvent = false;
+					try {
+						var ev = new CustomEvent('unhandledRejection');
+						hasCustomEvent = ev instanceof CustomEvent;
+					} catch (e) {}
+
+					return !hasCustomEvent ? noop : function(type, rejection) {
+						var ev = new CustomEvent(type, {
+							detail: {
+								reason: rejection.value,
+								key: rejection
+							},
+							bubbles: false,
+							cancelable: true
+						});
+
+						return !self.dispatchEvent(ev);
+					};
+				}(noop, self, CustomEvent));
+			}
+
+			return noop;
+		}
 
 		return Promise;
 	};

--- a/test/globalRejectionEvents-test.js
+++ b/test/globalRejectionEvents-test.js
@@ -1,0 +1,114 @@
+/*global process, window, setTimeout*/
+var buster = typeof window !== 'undefined' ? window.buster : require('buster');
+
+var CorePromise = require('../lib/Promise');
+
+var sentinel = { value: 'sentinel' };
+
+buster.testCase('global rejection events', {
+
+	'on Node': {
+		'tearDown': function() {
+			if(typeof process === 'undefined') {
+				return;
+			}
+
+			process.removeAllListeners('unhandledRejection');
+			process.removeAllListeners('rejectionHandled');
+		},
+
+		'should emit unhandledRejection': function(done) {
+			if(typeof window !== 'undefined') {
+				buster.assert(true);
+				return;
+			}
+
+			function listener(e) {
+				buster.assert.same(e, sentinel);
+				done();
+			}
+
+			process.on('unhandledRejection', listener);
+
+			CorePromise.reject(sentinel);
+		},
+
+		'should emit rejectionHandled': function(done) {
+			if(typeof window !== 'undefined') {
+				buster.assert(true);
+				return;
+			}
+
+			var r;
+			function unhandled(e, rejection) {
+				buster.assert.same(e, sentinel);
+				r = rejection;
+			}
+
+			function handled(rejection) {
+				buster.assert.same(rejection, r);
+				done();
+			}
+
+			process.on('unhandledRejection', unhandled);
+			process.on('rejectionHandled', handled);
+
+			var p = CorePromise.reject(sentinel);
+			setTimeout(function() {
+				p.catch(function() {});
+			}, 10);
+		}
+	},
+
+	'in Browser': {
+		'should emit unhandledRejection': function(done) {
+			if(typeof window === 'undefined') {
+				buster.assert(true);
+				done();
+				return;
+			}
+
+			function listener(e) {
+				window.removeEventListener('unhandledRejection', listener, false);
+				e.preventDefault();
+				buster.assert.same(e.detail.reason, sentinel);
+				done();
+			}
+
+			window.addEventListener('unhandledRejection', listener, false);
+
+			CorePromise.reject(sentinel);
+		},
+
+		'should emit rejectionHandled': function(done) {
+			if(typeof window === 'undefined') {
+				buster.assert(true);
+				done();
+				return;
+			}
+
+			var key;
+			function unhandled(e) {
+				window.removeEventListener('unhandledRejection', unhandled, false);
+				buster.assert.same(e.detail.reason, sentinel);
+				key = e.detail.key;
+			}
+
+			function handled(e) {
+				window.removeEventListener('rejectionHandled', handled, false);
+				buster.assert.same(e.detail.key, key);
+				done();
+			}
+
+			window.addEventListener('unhandledRejection', unhandled, false);
+			window.addEventListener('rejectionHandled', handled, false);
+
+			var p = CorePromise.reject(sentinel);
+			setTimeout(function() {
+				p.catch(function() {});
+			}, 10);
+		}
+	}
+
+});
+

--- a/test/monitor/index.html
+++ b/test/monitor/index.html
@@ -3,15 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <title></title>
-    <script type="text/javascript" src="../../bower_components/curl/src/curl.js"></script>
+    <script type="text/javascript" src="../../es6-shim/Promise.js"></script>
     <script type="text/javascript">
-        curl.config({
-            packages: {
-                when: { location: '../..', main: 'when' }
-            }
-        });
-
-        curl(['./done']);
+		window.addEventListener('unhandledRejection', function(event) {
+			console.log(event);
+		}, false);
+		Promise.reject(new Error('foo'));
     </script>
 </head>
 <body>


### PR DESCRIPTION
Docs and unit tests included.

This doesn't change the existing onPotentiallyUnhandledRejection
behavior.  It simply augments it when in a node/iojs env by emitting
unhandledRejection and rejectionHandled process events.

Close #419 