### PR TITLE
Fixed `createCallback` example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1623,7 +1623,7 @@ function nodeStyleAsyncFunction(callback) {
 }
 
 var deferred = when.defer();
-nodeStyleAsyncFunction(nodefn.createCallback(deferred.resolver));
+nodeStyleAsyncFunction(nodefn.createCallback(deferred));
 
 deferred.promise.then(function(interestingValue) {
   console.log(interestingValue)


### PR DESCRIPTION
According to the typings at https://github.com/borisyankov/DefinitelyTyped/blob/master/when/when.d.ts a deferred itself is a resolver which can be passed direclty to the `createCallback` method. 