### PR TITLE
Error message to be shown when formatting Error

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -20,7 +20,8 @@ define(function() {
 	 */
 	function formatError(e) {
 		var s = typeof e === 'object' && e !== null && e.stack ? e.stack : formatObject(e);
-		return e instanceof Error ? s : s + ' (WARNING: non-Error used)';
+		var m = typeof e === 'object' && e !== null && e.message ? e.message + '\n' : '';
+        	return e instanceof Error ? m + s : s + ' (WARNING: non-Error used)';
 	}
 
 	/**


### PR DESCRIPTION
In case an Error to be formatted has a message, add it on top of the error stack. Sometimes error message is more useful than error stack, which is oftentimes doesn't have anything except when.js methods chain.