### PR TITLE
Switch isNode check to avoid problem with webpack

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -42,8 +42,8 @@ define(function(require) {
 	};
 
 	function isNode () {
-		return typeof process !== 'undefined' && process !== null &&
-			typeof process.nextTick === 'function';
+		return typeof process !== 'undefined' &&
+			Object.prototype.toString.call(process) === '[object process]';
 	}
 
 	function hasMutationObserver () {


### PR DESCRIPTION
This should fix recently introduced incompatibility in webpack.

cc @KidkArolis 

Fix #449 