### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,7 @@
 		"ender"
 	],
 	"homepage": "http://cujojs.com",
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://www.opensource.org/licenses/mit-license.php"
-		}
-	],
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/cujojs/when"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/