### PR TITLE
Add array methods to promise prototype

### DIFF
--- a/lib/decorators/array.js
+++ b/lib/decorators/array.js
@@ -29,6 +29,11 @@ define(function(require) {
 		Promise.reduce = reduce;
 		Promise.reduceRight = reduceRight;
 
+		Promise.prototype.map = makeInstanceMethod(map);
+		Promise.prototype.filter = makeInstanceMethod(filter);
+		Promise.prototype.reduce = makeInstanceMethod(reduce);
+		Promise.prototype.reduceRight = makeInstanceMethod(reduceRight);
+
 		/**
 		 * When this promise fulfills with an array, do
 		 * onFulfilled.apply(void 0, array)
@@ -40,6 +45,20 @@ define(function(require) {
 				return onFulfilled.apply(this, array);
 			});
 		};
+
+		/**
+		 * Helper to generate a instance method wrapping a static array based method
+		 * such as map, filter, etc
+		 * @param {Function} staticMethod
+		 * @returns {Function}
+		 */
+		function makeInstanceMethod(staticMethod) {
+			return function (f) {
+				return this.then(all).then(function (array) {
+					return staticMethod.call(this, array, f);
+				});
+			};
+		}
 
 		return Promise;
 

--- a/lib/decorators/array.js
+++ b/lib/decorators/array.js
@@ -53,9 +53,11 @@ define(function(require) {
 		 * @returns {Function}
 		 */
 		function makeInstanceMethod(staticMethod) {
-			return function (f) {
+			return function () {
+				var args = slice.call(arguments);
 				return this.then(all).then(function (array) {
-					return staticMethod.call(this, array, f);
+					args.unshift(array);
+					return staticMethod.apply(this, args);
 				});
 			};
 		}

--- a/test/promise-test.js
+++ b/test/promise-test.js
@@ -705,6 +705,95 @@ buster.testCase('promise', {
 		}
 	},
 
+	'map': {
+		'should return a promise': function () {
+			assert.isFunction(when.defer().promise.map().then);
+		},
+
+		'should resolve to mapped array': function () {
+			var input = [1, 2, 3],
+				expected = [2, 4, 6];
+
+			return when.resolve(input)
+				.map(function (x) {
+					return 2 * x;
+				})
+				.then(function (result) {
+					assert.equals(result, expected);
+				});
+		},
+
+		'should preserve thisArg': function () {
+			return when.resolve([])
+				.withThis(sentinel)
+				.map(function () {
+					assert.equals(this, sentinel);
+				})
+				.then(function () {
+					assert.equals(this, sentinel);
+				});
+		},
+
+		'should resolve array contents': function () {
+			var input = [when.resolve(1), 2, when.resolve(3)],
+				expected = [2, 4, 6];
+
+			return when.resolve(input)
+				.map(function (x) {
+					return 2 * x;
+				})
+				.then(function (result) {
+					assert.equals(result, expected);
+				});
+		},
+
+		'should reject if any item in array rejects': function () {
+			var expected = [when.resolve(1), 2, when.reject(3)];
+			return when.resolve(expected)
+				.map(fail)
+				.then(fail, function () {
+					assert(true);
+				});
+		},
+
+		'when input is a promise': {
+			'should resolve to mapped array': function () {
+				var input = when.resolve([1, 2, 3]),
+					expected = [2, 4, 6];
+
+				return when.resolve(input)
+					.map(function (x) {
+						return 2 * x;
+					})
+					.then(function (result) {
+						assert.equals(result, expected);
+					});
+			},
+
+			'should resolve array contents': function () {
+				var input = when.resolve([when.resolve(1), 2, when.resolve(3)]),
+					expected = [2, 4, 6];
+
+				return when.resolve(input)
+					.map(function (x) {
+						return 2 * x;
+					})
+					.then(function (result) {
+						assert.equals(result, expected);
+					});
+			},
+
+			'should reject if input is a rejected promise': function () {
+				var expected = when.reject([1, 2, 3]);
+				return when.resolve(expected)
+					.map(fail)
+					.then(fail, function () {
+						assert(true);
+					});
+			}
+		}
+	},
+
 	'inspect': {
 
 		'when inspecting promises': {

--- a/test/promise-test.js
+++ b/test/promise-test.js
@@ -706,6 +706,26 @@ buster.testCase('promise', {
 	},
 
 	'map': {
+		setUp: function () {
+			this.runExpectResolve = function (input, expected) {
+				return when.resolve(input)
+					.map(function (x) {
+						return 2 * x;
+					})
+					.then(function (result) {
+						assert.equals(result, expected);
+					});
+			};
+
+			this.runExpectReject = function (input) {
+				return when.resolve(input)
+					.map(fail)
+					.then(fail, function () {
+						assert(true);
+					});
+			}
+		},
+
 		'should return a promise': function () {
 			assert.isFunction(when.defer().promise.map().then);
 		},
@@ -714,13 +734,7 @@ buster.testCase('promise', {
 			var input = [1, 2, 3],
 				expected = [2, 4, 6];
 
-			return when.resolve(input)
-				.map(function (x) {
-					return 2 * x;
-				})
-				.then(function (result) {
-					assert.equals(result, expected);
-				});
+			return this.runExpectResolve(input, expected);
 		},
 
 		'should preserve thisArg': function () {
@@ -738,22 +752,13 @@ buster.testCase('promise', {
 			var input = [when.resolve(1), 2, when.resolve(3)],
 				expected = [2, 4, 6];
 
-			return when.resolve(input)
-				.map(function (x) {
-					return 2 * x;
-				})
-				.then(function (result) {
-					assert.equals(result, expected);
-				});
+			return this.runExpectResolve(input, expected);
 		},
 
 		'should reject if any item in array rejects': function () {
-			var expected = [when.resolve(1), 2, when.reject(3)];
-			return when.resolve(expected)
-				.map(fail)
-				.then(fail, function () {
-					assert(true);
-				});
+			var input = [when.resolve(1), 2, when.reject(3)];
+
+			return this.runExpectReject(input);
 		},
 
 		'when input is a promise': {
@@ -761,35 +766,99 @@ buster.testCase('promise', {
 				var input = when.resolve([1, 2, 3]),
 					expected = [2, 4, 6];
 
-				return when.resolve(input)
-					.map(function (x) {
-						return 2 * x;
-					})
-					.then(function (result) {
-						assert.equals(result, expected);
-					});
+				return this.runExpectResolve(input, expected);
 			},
 
 			'should resolve array contents': function () {
 				var input = when.resolve([when.resolve(1), 2, when.resolve(3)]),
 					expected = [2, 4, 6];
 
+				return this.runExpectResolve(input, expected);
+			},
+
+			'should reject if input is a rejected promise': function () {
+				var input = when.reject([1, 2, 3]);
+
+				return this.runExpectReject(input);
+			}
+		}
+	},
+
+	'filter': {
+		setUp: function () {
+			this.runExpectResolve = function (input, expected) {
 				return when.resolve(input)
-					.map(function (x) {
-						return 2 * x;
+					.filter(function (x) {
+						return x % 2;
 					})
 					.then(function (result) {
 						assert.equals(result, expected);
 					});
-			},
+			};
 
-			'should reject if input is a rejected promise': function () {
-				var expected = when.reject([1, 2, 3]);
-				return when.resolve(expected)
-					.map(fail)
+			this.runExpectReject = function (input) {
+				return when.resolve(input)
+					.filter(fail)
 					.then(fail, function () {
 						assert(true);
 					});
+			}
+		},
+
+		'should return a promise': function () {
+			assert.isFunction(when.defer().promise.map().then);
+		},
+
+		'should preserve thisArg': function () {
+			return when.resolve([])
+				.withThis(sentinel)
+				.filter(function () {
+					assert.equals(this, sentinel);
+				})
+				.then(function () {
+					assert.equals(this, sentinel);
+				});
+		},
+
+		'should resolve to mapped array': function () {
+			var input = [1, 2, 3],
+				expected = [1, 3];
+
+			return this.runExpectResolve(input, expected);
+		},
+
+		'should resolve array contents': function () {
+			var input = [when.resolve(1), 2, when.resolve(3)],
+				expected = [1, 3];
+
+			return this.runExpectResolve(input, expected);
+		},
+
+		'should reject if any item in array rejects': function () {
+			var input = [when.resolve(1), 2, when.reject(3)];
+
+			return this.runExpectReject(input);
+		},
+
+		'when input is a promise': {
+			'should resolve to mapped array': function () {
+				var input = when.resolve([1, 2, 3]),
+					expected = [1, 3];
+
+				return this.runExpectResolve(input, expected);
+			},
+
+			'should resolve array contents': function () {
+				var input = when.resolve([when.resolve(1), 2, when.resolve(3)]),
+					expected = [1, 3];
+
+				return this.runExpectResolve(input, expected);
+			},
+
+			'should reject if input is a rejected promise': function () {
+				var input = when.reject([1, 2, 3]);
+
+				return this.runExpectReject(input);
 			}
 		}
 	},


### PR DESCRIPTION
For feedback and review. Implements issue #468.

Have not updated the docs at this point. If you are happy with the proposed change, I can amend with documentation updates to match.

For the case of a promise that doesn't resolve to an array being used, I've gone with the behaviour of resolving to an empty array to match the behaviour of the statically accessible functions.
