### PR TITLE
IE8 error messages

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -19,7 +19,7 @@ define(function() {
 	 * @returns {String} formatted string, suitable for output to developers
 	 */
 	function formatError(e) {
-		var s = typeof e === 'object' && e !== null && e.stack ? e.stack : formatObject(e);
+		var s = typeof e === 'object' && e !== null && (e.stack || e.message) ? e.stack || e.message : formatObject(e);
 		return e instanceof Error ? s : s + ' (WARNING: non-Error used)';
 	}
 


### PR DESCRIPTION
Hope all is really well there.

This came up in https://github.com/systemjs/systemjs/issues/894 to ensure that error messages without a stack show usefully in IE8.

Please do check I've done this right.