### PR TITLE
Use latest buster from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/when.js
 dist/
 test/browser/*.js
 bower_components/
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ build/
 *~
 bower.json
 bower_components/
+.idea

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "benchmark": "~1",
     "browserify": "~2",
-    "buster": "~0.7",
+    "buster": "git://github.com/busterjs/buster.git#update-deps",
     "exorcist": "~0.4",
     "jshint": "~2",
     "json5": "~0.2",


### PR DESCRIPTION
Please keep this open - it will spare me the trouble of setting up extra travis/saucelabs builds while I'm upgrading buster's dependencies.

Thanks :)
