### PR TITLE
Issue with browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "uglify-js": "~2",
     "wd": "~0.2"
   },
-  "main": "when",
+  "main": "when.js",
   "ender": {
     "files": [
       "*.js",


### PR DESCRIPTION
#### What's this PR purpose?

When you try to browserify a file which require when, you get this error : 
```javascript
Error: Cannot find module '../when' from '/Users/olivierlaniesse/src/iadvize/test/node_modules/when/dist/browser'
    at /Users/olivierlaniesse/src/iadvize/test/node_modules/browserify/node_modules/resolve/lib/async.js:55:21
    at load (/Users/olivierlaniesse/src/iadvize/test/node_modules/browserify/node_modules/resolve/lib/async.js:69:43)
    at onex (/Users/olivierlaniesse/src/iadvize/test/node_modules/browserify/node_modules/resolve/lib/async.js:92:31)
    at /Users/olivierlaniesse/src/iadvize/test/node_modules/browserify/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:99:15)
```

This PR aims to fix it :smiley: 

#### Step to reproduce

1. npm install --save when browserify
2. Edit a js file with this code (aka : test.js) :
```javascript
require('when')
```
3. run : browserify test.js
4. Read the error :)

#### Environnement

- npm v2.14.11
- when 3.7.6
