### PR TITLE
Correct promise.tap "equivalent" explanation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -579,8 +579,7 @@ These are equivalent:
 ```js
 // Using only .then()
 promise.then(function(x) {
-	doSideEffectsHere(x);
-	return x;
+	return when(doSideEffectsHere(x)).yield(x);
 });
 
 // Using .tap()


### PR DESCRIPTION
I'm far from certain about this, but I don't think the "equivalent" JS code for `promise.tap` was correct.

According to the description of the function, `promise.tap` should wait for `doSideEffectsHere`'s return, and should reject if `doSideEffectsHere()` returns a rejected promise. Which the "equivalent" code didn't achieve. I think.