### PR TITLE
Update of microtime dependency (so that npm install works on Node 4 and 5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,22 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
+  - '4'
+  - '5'
 sudo: false
 script: npm run ci
 branches:
   only:
     - dev
     - master
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 env:
   global:
     - SAUCE_USERNAME="cujojs-when"
     - SAUCE_ACCESS_KEY="e5d3d1a5-bc49-4607-8a7e-702a512c7f60"
+    - CXX=g++-4.8

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "exorcist": "~0.4",
     "jshint": "~2",
     "json5": "~0.2",
-    "microtime": "~0",
+    "microtime": "~2",
     "optimist": "~0.6",
     "poly": "^0.6.1",
     "promises-aplus-tests": "~2",


### PR DESCRIPTION
when should not use an old version of microtime (~0) because it doesn't compile against Node.js 4 and 5 (i.e. npm install fails because of microtime there). The latest version of microtime (~2) works with all Node.js versions.