### PR TITLE
Make sure MutationObserver is used in Safari as well

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -47,7 +47,8 @@ define(function(require) {
 	}
 
 	function hasMutationObserver () {
-		return window['MutationObserver'] || window['WebKitMutationObserver'];
+	    return (typeof MutationObserver !== 'undefined' && MutationObserver) ||
+			(typeof WebKitMutationObserver !== 'undefined' && WebKitMutationObserver);
 	}
 
 	function initMutationObserver(MutationObserver) {

--- a/lib/env.js
+++ b/lib/env.js
@@ -47,8 +47,7 @@ define(function(require) {
 	}
 
 	function hasMutationObserver () {
-		return (typeof MutationObserver === 'function' && MutationObserver) ||
-			(typeof WebKitMutationObserver === 'function' && WebKitMutationObserver);
+		return window['MutationObserver'] || window['WebKitMutationObserver'];
 	}
 
 	function initMutationObserver(MutationObserver) {


### PR DESCRIPTION
Calling `typeof MutationObserver` in Safari will return 'object' instead of 'function' (tested in Safari 9.1).