### PR TITLE
Fix unhandled rejection warnings in when.settle (#493)

### DIFF
--- a/lib/decorators/array.js
+++ b/lib/decorators/array.js
@@ -239,13 +239,23 @@ define(function(require) {
 		}
 
 		function settleOne(p) {
-			var h = Promise._handler(p);
-			if(h.state() === 0) {
+			// Optimize the case where we get an already-resolved when.js promise
+			//  by extracting its state:
+			var handler;
+			if (p instanceof Promise) {
+				// This is our own Promise type and we can reach its handler internals:
+				handler = p._handler.join();
+			}
+			if((handler && handler.state() === 0) || !handler) {
+				// Either still pending, or not a Promise at all:
 				return toPromise(p).then(state.fulfilled, state.rejected);
 			}
 
-			h._unreport();
-			return state.inspect(h);
+			// The promise is our own, but it is already resolved. Take a shortcut.
+			// Since we're not actually handling the resolution, we need to disable
+			// rejection reporting.
+			handler._unreport();
+			return state.inspect(handler);
 		}
 
 		/**


### PR DESCRIPTION
* Fix unhandled rejection warnings that resulted from creating superfluous Thenables during optimizations in settleOne() when working with foreign Promise objects