### PR TITLE
Emit unhandledRejection on Internet Explorer (+ fixes on Windows)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,5 @@ Note that when.js includes the [Promises/A+ Test Suite](https://github.com/promi
 #### Browsers
 
 1. `npm install`
-2. `npm start` - starts buster server & prints a url
-3. Point browsers at <buster server url>/capture, e.g. `localhost:1111/capture`
-4. `npm run test-browser`
+2. `npm run browser-test`
+3. Point browsers at <buster server url>, e.g. `http://localhost:8080/`

--- a/lib/makePromise.js
+++ b/lib/makePromise.js
@@ -882,6 +882,28 @@ define(function() {
 
 		function noop() {}
 
+		function hasCustomEvent() {
+			if(typeof CustomEvent === 'function') {
+				try {
+					var ev = new CustomEvent('unhandledRejection');
+					return ev instanceof CustomEvent;
+				} catch (ignoredException) {}
+			}
+			return false;
+		}
+
+		function hasInternetExplorerCustomEvent() {
+			if(typeof document !== 'undefined' && typeof document.createEvent === 'function') {
+				try {
+					// Try to create one event to make sure it's supported
+					var ev = document.createEvent('CustomEvent');
+					ev.initCustomEvent('eventType', false, true, {});
+					return true;
+				} catch (ignoredException) {}
+			}
+			return false;
+		}
+
 		function initEmitRejection() {
 			/*global process, self, CustomEvent*/
 			if(typeof process !== 'undefined' && process !== null
@@ -895,15 +917,9 @@ define(function() {
 						? process.emit(type, rejection.value, rejection)
 						: process.emit(type, rejection);
 				};
-			} else if(typeof self !== 'undefined' && typeof CustomEvent === 'function') {
-				return (function(noop, self, CustomEvent) {
-					var hasCustomEvent = false;
-					try {
-						var ev = new CustomEvent('unhandledRejection');
-						hasCustomEvent = ev instanceof CustomEvent;
-					} catch (e) {}
-
-					return !hasCustomEvent ? noop : function(type, rejection) {
+			} else if(typeof self !== 'undefined' && hasCustomEvent()) {
+				return (function (self, CustomEvent) {
+					return function (type, rejection) {
 						var ev = new CustomEvent(type, {
 							detail: {
 								reason: rejection.value,
@@ -915,7 +931,19 @@ define(function() {
 
 						return !self.dispatchEvent(ev);
 					};
-				}(noop, self, CustomEvent));
+				}(self, CustomEvent));
+			} else if(typeof self !== 'undefined' && hasInternetExplorerCustomEvent()) {
+				return (function(self, document) {
+					return function(type, rejection) {
+						var ev = document.createEvent('CustomEvent');
+						ev.initCustomEvent(type, false, true, {
+							reason: rejection.value,
+							key: rejection
+						});
+
+						return !self.dispatchEvent(ev);
+					};
+				}(self, document));
 			}
 
 			return noop;

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "browserify": "~2",
     "buster": "~0.7",
     "exorcist": "~0.4",
+    "glob": "^7.1.1",
     "jshint": "~2",
     "json5": "~0.2",
     "microtime": "~2",
@@ -82,7 +83,7 @@
   },
   "scripts": {
     "test": "jshint . && buster-test -e node && promises-aplus-tests test/promises-aplus-adapter.js",
-    "build-browser-test": "browserify ./node_modules/poly/es5.js -o test/browser/es5.js && browserify ./test/*-test.js ./test/**/*-test.js -o test/browser/tests.js -x buster ",
+    "build-browser-test": "browserify ./node_modules/poly/es5.js -o test/browser/es5.js && node scripts/browserify-tests",
     "browser-test": "npm run build-browser-test && buster-static -e browser -p 8080",
     "ci": "npm test && node test/sauce.js",
     "tunnel": "node test/sauce.js -m",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "jshint": "~2",
     "json5": "~0.2",
     "microtime": "~2",
+    "mkdirp": "^0.5.1",
     "optimist": "~0.6",
     "poly": "^0.6.1",
     "promises-aplus-tests": "~2",
@@ -90,11 +91,11 @@
     "prepublish": "npm run browserify && npm run uglify",
     "preversion": "npm run browserify && npm run uglify",
     "browserify": "npm run browserify-es6 && npm run browserify-when && npm run browserify-debug",
-    "browserify-es6": "browserify -s Promise es6-shim/Promise.browserify-es6.js --no-detect-globals --debug | exorcist -b . -r https://raw.githubusercontent.com/cujojs/when/`git rev-parse HEAD` es6-shim/Promise.js.map >es6-shim/Promise.js",
-    "browserify-when": "mkdir -p dist/browser && browserify -s when build/when.browserify.js --no-detect-globals --debug | exorcist -b . -r https://raw.githubusercontent.com/cujojs/when/`git rev-parse HEAD` dist/browser/when.js.map >dist/browser/when.js",
-    "browserify-debug": "mkdir -p dist/browser && browserify -s when build/when.browserify-debug.js --no-detect-globals --debug | exorcist -b . -r https://raw.githubusercontent.com/cujojs/when/`git rev-parse HEAD` dist/browser/when.debug.js.map >dist/browser/when.debug.js",
+    "browserify-es6": "node scripts/browserify.js es6",
+    "browserify-when": "node scripts/browserify.js when",
+    "browserify-debug": "node scripts/browserify.js debug",
     "uglify": "npm run uglify-es6 && npm run uglify-when",
-    "uglify-es6": "cd es6-shim; uglifyjs Promise.js --compress --mangle  --in-source-map Promise.js.map --source-map Promise.min.js.map -o Promise.min.js; cd ../..",
-    "uglify-when": "cd dist/browser; uglifyjs when.js --compress --mangle  --in-source-map when.js.map --source-map when.min.js.map -o when.min.js; cd ../.."
+    "uglify-es6": "uglifyjs es6-shim/Promise.js --compress --mangle  --in-source-map es6-shim/Promise.js.map --source-map es6-shim/Promise.min.js.map -o es6-shim/Promise.min.js",
+    "uglify-when": "uglifyjs dist/browser/when.js --compress --mangle  --in-source-map dist/browser/when.js.map --source-map dist/browser/when.min.js.map -o dist/browser/when.min.js"
   }
 }

--- a/scripts/browserify-tests.js
+++ b/scripts/browserify-tests.js
@@ -1,0 +1,23 @@
+var path = require('path');
+var fs = require('fs');
+var glob = require('glob');
+var browserify = require('browserify');
+
+var POSIX_SEP = path.posix ? path.posix.sep : '/';
+
+var ROOT_DIR = path.resolve(__dirname, '..');
+var outputFile = path.resolve(ROOT_DIR, 'test', 'browser', 'tests.js');
+
+var entries = glob(path.join(ROOT_DIR, 'test', '**', '*-test.js'), { sync: true });
+if (path.sep !== POSIX_SEP) {
+	entries = entries.map(function (entry) {
+		return entry.split(POSIX_SEP).join(path.sep);
+	});
+}
+
+browserify({
+	entries: entries
+})
+	.external('buster')
+	.bundle()
+	.pipe(fs.createWriteStream(outputFile));

--- a/scripts/browserify.js
+++ b/scripts/browserify.js
@@ -1,0 +1,83 @@
+var exec = require('child_process').exec;
+var path = require('path');
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var browserify = require('browserify');
+var exorcist = require('exorcist');
+
+var ROOT_DIR = path.resolve(__dirname, '..');
+
+var CONFIGURATIONS = {
+	'es6': {
+		standaloneName: 'Promise',
+		entries: [
+			path.resolve(ROOT_DIR, 'es6-shim', 'Promise.browserify-es6.js')
+		],
+		outputDir: 'es6-shim',
+		outputFilename: 'Promise.js'
+	},
+	'when': {
+		standaloneName: 'when',
+		entries: [
+			path.resolve(ROOT_DIR, 'build', 'when.browserify.js')
+		],
+		outputDir: path.join('dist', 'browser'),
+		outputFilename: 'when.js'
+	},
+	'debug': {
+		standaloneName: 'when',
+		entries: [
+			path.resolve(ROOT_DIR, 'build', 'when.browserify-debug.js')
+		],
+		outputDir: path.join('dist', 'browser'),
+		outputFilename: 'when.debug.js'
+	}
+};
+
+function revParse(callback) {
+	exec('git rev-parse HEAD', function(err, stdout, stderr) {
+		process.stderr.write(stderr);
+		if (err) {
+			callback(err);
+		} else {
+			callback(null, stdout.replace(/(^\s+)|(\s+$)/g, ''));
+		}
+	});
+}
+
+var configName = process.argv[2];
+var config = CONFIGURATIONS[configName];
+
+if (!config) {
+	console.error('Cannot find configuration "' + configName + '"');
+	process.exit(1);
+	return;
+}
+
+mkdirp(config.outputDir, function(mkdirErr) {
+	if (mkdirErr) {
+		console.error(mkdirErr);
+		process.exit(1);
+	} else {
+		revParse(function(revParseErr, rev) {
+			if (revParseErr) {
+				console.error(revParseErr);
+				process.exit(1);
+			} else {
+				var rootUrl = 'https://raw.githubusercontent.com/cujojs/when/' + rev;
+				var outputMapFile = path.resolve(ROOT_DIR, config.outputDir, config.outputFilename + '.map');
+				var outputFile = path.resolve(ROOT_DIR, config.outputDir, config.outputFilename);
+				browserify({
+					entries: config.entries
+				})
+					.bundle({
+						standalone: config.standaloneName,
+						detectGlobals: false,
+						debug: true
+					})
+					.pipe(exorcist(outputMapFile, null, rootUrl, ROOT_DIR))
+					.pipe(fs.createWriteStream(outputFile));
+			}
+		});
+	}
+});

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>when.js browser tests</title>
-    <script src="es5.js"></script>
+    <script src="test/browser/es5.js"></script>
 </head>
 <body></body>
 </html>

--- a/test/buster.js
+++ b/test/buster.js
@@ -8,9 +8,12 @@ exports.node = {
 
 exports.browser = {
 	environment: 'browser',
-	rootPath: '../',
+	rootPath: '..',
 	tests: [
 		'test/browser/tests.js'
+	],
+	resources: [
+		'test/browser/es5.js'
 	],
 	testbed: 'test/browser/index.html'
 };

--- a/test/globalRejectionEvents-test.js
+++ b/test/globalRejectionEvents-test.js
@@ -9,7 +9,7 @@ buster.testCase('global rejection events', {
 
 	'on Node': {
 		'tearDown': function() {
-			if(typeof process === 'undefined') {
+			if(typeof window !== 'undefined') {
 				return;
 			}
 
@@ -20,6 +20,7 @@ buster.testCase('global rejection events', {
 		'should emit unhandledRejection': function(done) {
 			if(typeof window !== 'undefined') {
 				buster.assert(true);
+				done();
 				return;
 			}
 
@@ -36,6 +37,7 @@ buster.testCase('global rejection events', {
 		'should emit rejectionHandled': function(done) {
 			if(typeof window !== 'undefined') {
 				buster.assert(true);
+				done();
 				return;
 			}
 


### PR DESCRIPTION
Hello,

This Pull Request is to emit the `unhandledRejection` event on Internet Explorer, which doesn't support the `CustomEvent` class.

I've manually tested on Internet Explorer 9 and 11.

Also provide some fixes to build and test on Windows.