### PR TITLE
Change jsdoc for type "array" to "Array"

### DIFF
--- a/when.js
+++ b/when.js
@@ -175,7 +175,7 @@ define(function (require) {
 	/**
 	 * Return a promise that will fulfill once all input promises have
 	 * fulfilled, or reject when any one input promise rejects.
-	 * @param {array|Promise} promises array (or promise for an array) of promises
+	 * @param {Array<Promise>|Promise} promises array (or promise for an array) of promises
 	 * @returns {Promise}
 	 */
 	function all(promises) {
@@ -186,7 +186,7 @@ define(function (require) {
 	 * Return a promise that will always fulfill with an array containing
 	 * the outcome states of all input promises.  The returned promise
 	 * will only reject if `promises` itself is a rejected promise.
-	 * @param {array|Promise} promises array (or promise for an array) of promises
+	 * @param {Array<Promise>|Promise} promises array (or promise for an array) of promises
 	 * @returns {Promise} promise for array of settled state descriptors
 	 */
 	function settle(promises) {


### PR DESCRIPTION
When passing an array to some when functions, there is a type warning because "array" should be "Array".
This fixes the few places where lowercase "array" is used.

![screen shot 2017-10-24 at 3 22 39 pm](https://user-images.githubusercontent.com/28719012/31971260-df82e3ac-b8cf-11e7-80da-1df4cacc7e17.png)
