### PR TITLE
call the catch handler only if it is a function

### DIFF
--- a/lib/decorators/flow.js
+++ b/lib/decorators/flow.js
@@ -53,7 +53,7 @@ define(function() {
 		 */
 		function createCatchFilter(handler, predicate) {
 			return function(e) {
-				return evaluatePredicate(e, predicate)
+				return evaluatePredicate(e, predicate) && typeof handler === 'function'
 					? handler.call(this, e)
 					: reject(e);
 			};


### PR DESCRIPTION
Hello,

You should include the type check on catch handler because if a handler is not a function, the catch method throws the TypeError 

> TypeError: handler.call is not a function

For example, check the following code:
```
var p1 = Promise.resolve(18);
var p2 = Promise.reject(17);
p2.catch(function(){
return p1;
}, p1);
```
The second argument is non-function value and in this case the TypeError is thrown becuase method _call_ can't be called on a non-function object.  
