### PR TITLE
Fix custom inspection in new Node.js versions

### DIFF
--- a/lib/decorators/inspect.js
+++ b/lib/decorators/inspect.js
@@ -13,6 +13,11 @@ define(function(require) {
 			return inspect(Promise._handler(this));
 		};
 
+		try {
+			var custom = require('util').util.inspect.custom;
+			Promise.prototype[custom] = Promise.prototype.inspect;
+		} catch (err) {}
+
 		return Promise;
 	};
 

--- a/lib/state.js
+++ b/lib/state.js
@@ -3,14 +3,21 @@
 /** @author John Hann */
 
 (function(define) { 'use strict';
-define(function() {
+define(function(require) {
 
-	return {
+	var res = {
 		pending: toPendingState,
 		fulfilled: toFulfilledState,
 		rejected: toRejectedState,
 		inspect: inspect
 	};
+
+	try {
+		var custom = require('util').util.inspect.custom;
+		res[custom] = inspect;
+	} catch (err) {}
+
+	return res;
 
 	function toPendingState() {
 		return { state: 'pending' };


### PR DESCRIPTION
Newer Node.js versions export a special symbol that should be used
to custom inspect objects. Otherwise the object itself would be
poluted.
This adds the symbol in the most backwards compatible way possible:
it prevents any deprecation message from showing up and behaves just
as before. Otherwise the custom inspection will break in Node.js 11.

I am not sure if it is the best way to tackle this, so I did not add any tests.