### PR TITLE
Resolving vertx dependency issues with webpack

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -29,7 +29,7 @@ define(function(require) {
 
 	} else if (!capturedSetTimeout) { // vert.x
 		var vertxRequire = require;
-		var vertx = vertxRequire('vertx');
+		var vertx = vertxRequire('@vertx/core');
 		setTimer = function (f, ms) { return vertx.setTimer(ms, f); };
 		clearTimer = vertx.cancelTimer;
 		asap = vertx.runOnLoop || vertx.runOnContext;

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mkdirp": "^0.5.1",
     "optimist": "~0.6",
     "poly": "^0.6.1",
+		"@vertx/core": "^4.0.0",
     "promises-aplus-tests": "~2",
     "rest": "1.1.x",
     "sauce-connect-launcher": "~0.4",


### PR DESCRIPTION
What I’ve changed:
In /lib/env.js, the vertx require statement now uses @vertx/core, which is the node package for vertx. This resolves an issue when using webpack (see #482)
package.json has also been updated to include @vertx/core as a dependency. 

